### PR TITLE
Dev daily window state refresh

### DIFF
--- a/src/database/schema/collection_queue.ts
+++ b/src/database/schema/collection_queue.ts
@@ -238,43 +238,62 @@ export async function initCollectionQueueSchema(pool: Pool): Promise<void> {
         FROM video_collection_state
         WHERE priority <> -1
       ),
-      samples AS (
-        SELECT vdl.aid, vdl.updated_at AS sample_time, vdl."view"::bigint AS view_count
-        FROM video_daily_latest vdl
-        JOIN active_state state ON state.aid = vdl.aid
-        WHERE vdl."view" IS NOT NULL
-        UNION ALL
-        SELECT vd.aid, vd.record_date::timestamptz AS sample_time, vd."view"::bigint AS view_count
-        FROM video_daily vd
-        JOIN active_state state ON state.aid = vd.aid
-        WHERE vd."view" IS NOT NULL
-        UNION ALL
-        SELECT vm.aid, vm."time" AS sample_time, vm."view"::bigint AS view_count
-        FROM video_minute vm
-        JOIN active_state state ON state.aid = vm.aid
-        WHERE vm."view" IS NOT NULL
-      ),
-      ranked AS (
-        SELECT
-          s.*,
-          row_number() OVER (PARTITION BY aid ORDER BY sample_time DESC) AS rn
-        FROM samples s
-      ),
       paired AS (
         SELECT
-          current_sample.aid,
-          current_sample.sample_time AS current_sample_time,
-          current_sample.view_count AS current_view,
-          previous_sample.sample_time AS previous_sample_time,
-          previous_sample.view_count AS previous_view,
+          state.aid,
+          max(samples.sample_time) FILTER (WHERE samples.rn = 1) AS current_sample_time,
+          max(samples.view_count) FILTER (WHERE samples.rn = 1) AS current_view,
+          max(samples.sample_time) FILTER (WHERE samples.rn = 2) AS previous_sample_time,
+          max(samples.view_count) FILTER (WHERE samples.rn = 2) AS previous_view,
           state.priority,
           state.next_minute_due_at
-        FROM ranked current_sample
-        JOIN active_state state ON state.aid = current_sample.aid
-        LEFT JOIN ranked previous_sample
-          ON previous_sample.aid = current_sample.aid
-         AND previous_sample.rn = 2
-        WHERE current_sample.rn = 1
+        FROM active_state state
+        LEFT JOIN LATERAL (
+          SELECT
+            ranked_samples.sample_time,
+            ranked_samples.view_count,
+            ranked_samples.rn
+          FROM (
+            SELECT
+              candidate_samples.sample_time,
+              candidate_samples.view_count,
+              row_number() OVER (ORDER BY candidate_samples.sample_time DESC) AS rn
+            FROM (
+              SELECT
+                vdl.updated_at AS sample_time,
+                vdl."view"::bigint AS view_count
+              FROM video_daily_latest vdl
+              WHERE vdl.aid = state.aid
+                AND vdl."view" IS NOT NULL
+              UNION ALL
+              SELECT
+                recent_daily.record_date::timestamptz AS sample_time,
+                recent_daily."view"::bigint AS view_count
+              FROM (
+                SELECT vd.record_date, vd."view"
+                FROM video_daily vd
+                WHERE vd.aid = state.aid
+                  AND vd."view" IS NOT NULL
+                ORDER BY vd.record_date DESC
+                LIMIT 2
+              ) recent_daily
+              UNION ALL
+              SELECT
+                recent_minute."time" AS sample_time,
+                recent_minute."view"::bigint AS view_count
+              FROM (
+                SELECT vm."time", vm."view"
+                FROM video_minute vm
+                WHERE vm.aid = state.aid
+                  AND vm."view" IS NOT NULL
+                ORDER BY vm."time" DESC
+                LIMIT 2
+              ) recent_minute
+            ) candidate_samples
+          ) ranked_samples
+          WHERE ranked_samples.rn <= 2
+        ) samples ON true
+        GROUP BY state.aid, state.priority, state.next_minute_due_at
       ),
       candidates AS (
         SELECT

--- a/src/database/schema/collection_state.ts
+++ b/src/database/schema/collection_state.ts
@@ -138,48 +138,35 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
     DECLARE
       changed_count integer;
     BEGIN
-      WITH business_day AS (
-        SELECT (p_now AT TIME ZONE p_business_timezone)::date AS today
+      WITH target_dates AS (
+        SELECT
+          (p_now AT TIME ZONE p_business_timezone)::date AS today,
+          ((p_now AT TIME ZONE p_business_timezone)::date - 1) AS yesterday,
+          ((p_now AT TIME ZONE p_business_timezone)::date - 7) AS seven_days_ago
       ),
-      source_aids AS (
-        SELECT DISTINCT vd.aid
-        FROM video_daily vd, business_day bd
-        WHERE vd.record_date < bd.today
-          AND (p_aids IS NULL OR vd.aid = ANY(p_aids))
-      ),
-      latest AS (
-        SELECT DISTINCT ON (vd.aid)
+      current_rows AS (
+        SELECT
           vd.aid,
-          vd.record_date,
           vd."view"::bigint AS current_view
         FROM video_daily vd
-        JOIN source_aids sa ON sa.aid = vd.aid
-        JOIN business_day bd ON vd.record_date < bd.today
-        ORDER BY vd.aid, vd.record_date DESC
+        JOIN target_dates td ON vd.record_date = td.today
+        WHERE p_aids IS NULL OR vd.aid = ANY(p_aids)
       ),
       measured AS (
         SELECT
-          l.aid,
-          l.record_date,
-          l.current_view,
-          prev."view"::bigint AS previous_view,
+          c.aid,
+          td.today AS record_date,
+          c.current_view,
+          yesterday."view"::bigint AS previous_view,
           seven."view"::bigint AS seven_day_view
-        FROM latest l
-        LEFT JOIN LATERAL (
-          SELECT vd."view"
-          FROM video_daily vd
-          WHERE vd.aid = l.aid
-            AND vd.record_date < l.record_date
-          ORDER BY vd.record_date DESC
-          LIMIT 1
-        ) prev ON true
-        LEFT JOIN LATERAL (
-          SELECT vd."view"
-          FROM video_daily vd
-          WHERE vd.aid = l.aid
-            AND vd.record_date = l.record_date - 7
-          LIMIT 1
-        ) seven ON true
+        FROM current_rows c
+        CROSS JOIN target_dates td
+        LEFT JOIN video_daily yesterday
+          ON yesterday.aid = c.aid
+         AND yesterday.record_date = td.yesterday
+        LEFT JOIN video_daily seven
+          ON seven.aid = c.aid
+         AND seven.record_date = td.seven_days_ago
       ),
       calculated AS (
         SELECT
@@ -293,23 +280,7 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
   `);
 
   await pool.query(`
-    CREATE OR REPLACE FUNCTION fn_refresh_video_collection_state_from_daily(
-      p_aids bigint[],
-      p_now timestamptz
-    ) RETURNS integer AS $$
-    BEGIN
-      RETURN fn_refresh_video_collection_state_from_daily(
-        p_aids,
-        p_now,
-        ${config.minute.targetDeltaPerSample},
-        ${config.minute.targetDeltaLower},
-        ${config.minute.targetDeltaUpper},
-        ${config.minute.minPositivePriority},
-        ${config.minute.maxPositivePriority},
-        '${sqlText(config.minute.collectionBusinessTimezone)}'
-      );
-    END;
-    $$ LANGUAGE plpgsql
+    DROP FUNCTION IF EXISTS fn_refresh_video_collection_state_from_daily(bigint[], timestamptz)
   `);
 
   await pool.query(`

--- a/src/database/videoDaily.ts
+++ b/src/database/videoDaily.ts
@@ -33,41 +33,34 @@ export async function getDailyCollectionCandidates(
 ): Promise<DailyCollectionCandidate[]> {
   const result = await pool.query(
     `
-    WITH business_day AS (
-      SELECT ($1::timestamptz AT TIME ZONE $2)::date AS today
+    WITH target_dates AS (
+      SELECT
+        ($1::timestamptz AT TIME ZONE $2)::date AS today,
+        (($1::timestamptz AT TIME ZONE $2)::date - 1) AS yesterday,
+        (($1::timestamptz AT TIME ZONE $2)::date - 7) AS seven_days_ago
     ),
-    latest AS (
-      SELECT DISTINCT ON (vd.aid)
+    current_rows AS (
+      SELECT
         vd.aid,
-        vd.record_date,
         vd."view"::bigint AS current_view
       FROM video_daily vd
-      JOIN business_day bd ON vd.record_date < bd.today
-      ORDER BY vd.aid, vd.record_date DESC
+      JOIN target_dates td ON vd.record_date = td.today
     ),
     measured AS (
       SELECT
-        l.aid,
-        l.record_date,
-        l.current_view,
-        prev."view"::bigint AS previous_view,
+        c.aid,
+        td.today AS record_date,
+        c.current_view,
+        yesterday."view"::bigint AS previous_view,
         seven."view"::bigint AS seven_day_view
-      FROM latest l
-      LEFT JOIN LATERAL (
-        SELECT vd."view"
-        FROM video_daily vd
-        WHERE vd.aid = l.aid
-          AND vd.record_date < l.record_date
-        ORDER BY vd.record_date DESC
-        LIMIT 1
-      ) prev ON true
-      LEFT JOIN LATERAL (
-        SELECT vd."view"
-        FROM video_daily vd
-        WHERE vd.aid = l.aid
-          AND vd.record_date = l.record_date - 7
-        LIMIT 1
-      ) seven ON true
+      FROM current_rows c
+      CROSS JOIN target_dates td
+      LEFT JOIN video_daily yesterday
+        ON yesterday.aid = c.aid
+       AND yesterday.record_date = td.yesterday
+      LEFT JOIN video_daily seven
+        ON seven.aid = c.aid
+       AND seven.record_date = td.seven_days_ago
     )
     SELECT
       m.aid,


### PR DESCRIPTION
This pull request refactors and streamlines the logic for collecting and measuring video view statistics in both the schema and query layers. The main improvements are to how current, previous, and seven-day view counts are calculated, making the SQL queries more efficient and easier to understand. Additionally, an obsolete function is dropped from the schema.

Key changes include:

**Refactoring date-based view calculations:**

* Simplified the logic for fetching current, previous, and seven-day view counts in both `fn_refresh_video_collection_state_from_daily` and `getDailyCollectionCandidates` by introducing a `target_dates` CTE and joining directly on calculated dates, replacing the previous use of `DISTINCT ON` and lateral joins. [[1]](diffhunk://#diff-074ac357d29a5f48137b87134dcb64875f12c3f1e4170a522448822b6bffd118L141-R169) [[2]](diffhunk://#diff-f62387e82a0744ae5dd2f0131cfb708241c395a4c814d3a53f4531d6d1ffbc93L36-R63)

**Optimizing collection queue pairing logic:**

* Rewrote the pairing logic in `initCollectionQueueSchema` to use a single lateral join that collects up to two of the most recent view samples from multiple sources (`video_daily_latest`, `video_daily`, `video_minute`), and then aggregates them for current and previous sample calculations, reducing complexity and improving maintainability.

**Schema cleanup:**

* Dropped the obsolete function `fn_refresh_video_collection_state_from_daily(bigint[], timestamptz)` from the schema, as its logic is now handled by the refactored code.