### PR TITLE
perf: prevent gate enqueue blocking minute tasks

### DIFF
--- a/src/database/schema/collection_queue.ts
+++ b/src/database/schema/collection_queue.ts
@@ -36,6 +36,17 @@ export async function initCollectionQueueSchema(pool: Pool): Promise<void> {
   `);
 
   await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_video_collection_queue_claim_order
+    ON video_collection_queue(
+      status,
+      (CASE WHEN task_type = 'minute' THEN 0 ELSE 1 END),
+      due_at,
+      id
+    )
+    WHERE status IN ('pending', 'leased')
+  `);
+
+  await pool.query(`
     CREATE INDEX IF NOT EXISTS idx_video_collection_queue_abandoned_dedupe
     ON video_collection_queue(dedupe_key)
     WHERE status = 'abandoned'
@@ -45,6 +56,12 @@ export async function initCollectionQueueSchema(pool: Pool): Promise<void> {
     CREATE INDEX IF NOT EXISTS idx_video_collection_queue_cleanup
     ON video_collection_queue(updated_at)
     WHERE status IN ('completed', 'abandoned')
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_video_collection_queue_active_aid_type
+    ON video_collection_queue(aid, task_type, status)
+    WHERE status IN ('pending', 'leased')
   `);
 
   await pool.query(`
@@ -240,9 +257,46 @@ export async function initCollectionQueueSchema(pool: Pool): Promise<void> {
       inserted_count integer;
     BEGIN
       WITH active_state AS (
-        SELECT aid, priority, next_minute_due_at
-        FROM video_collection_state
-        WHERE priority <> -1
+        SELECT
+          s.aid,
+          s.priority,
+          s.next_minute_due_at,
+          vdl.updated_at AS latest_daily_sample_time,
+          vdl."view"::bigint AS latest_daily_view
+        FROM video_collection_state s
+        LEFT JOIN video_daily_latest vdl ON vdl.aid = s.aid
+        WHERE s.priority <> -1
+          AND NOT EXISTS (
+            SELECT 1
+            FROM video_collection_queue q
+            WHERE q.aid = s.aid
+              AND q.task_type = 'gate'
+              AND q.status IN ('pending', 'leased')
+          )
+          AND (
+            (
+              s.priority > 0
+              AND s.next_minute_due_at IS NOT NULL
+              AND s.next_minute_due_at <= p_now + p_gate_lead_time
+            )
+            OR fn_video_collection_exact_gate_value(vdl."view"::bigint) IS NOT NULL
+            OR (
+              fn_video_collection_next_gate_value(vdl."view"::bigint) IS NOT NULL
+              AND fn_video_collection_next_gate_value(vdl."view"::bigint) - vdl."view"::bigint <= least(
+                ceil(fn_video_collection_next_gate_value(vdl."view"::bigint) * p_gate_min_lead_ratio)::bigint,
+                p_gate_max_lead_views
+              )
+            )
+          )
+        ORDER BY
+          CASE
+            WHEN s.priority > 0
+             AND s.next_minute_due_at IS NOT NULL
+            THEN s.next_minute_due_at
+            ELSE p_now
+          END ASC,
+          s.aid ASC
+        LIMIT 1000
       ),
       paired AS (
         SELECT
@@ -266,11 +320,9 @@ export async function initCollectionQueueSchema(pool: Pool): Promise<void> {
               row_number() OVER (ORDER BY candidate_samples.sample_time DESC) AS rn
             FROM (
               SELECT
-                vdl.updated_at AS sample_time,
-                vdl."view"::bigint AS view_count
-              FROM video_daily_latest vdl
-              WHERE vdl.aid = state.aid
-                AND vdl."view" IS NOT NULL
+                state.latest_daily_sample_time AS sample_time,
+                state.latest_daily_view AS view_count
+              WHERE state.latest_daily_view IS NOT NULL
               UNION ALL
               SELECT
                 recent_daily.record_date::timestamptz AS sample_time,
@@ -430,7 +482,7 @@ export async function initCollectionQueueSchema(pool: Pool): Promise<void> {
             OR (q.status = 'leased' AND q.locked_until <= p_now)
           )
         ORDER BY
-          q.task_type ASC,
+          CASE WHEN q.task_type = 'minute' THEN 0 ELSE 1 END ASC,
           q.due_at ASC,
           q.id ASC
         LIMIT p_limit

--- a/src/database/schema/video_daily.ts
+++ b/src/database/schema/video_daily.ts
@@ -42,6 +42,11 @@ export async function initVideoDailySchema(pool: Pool): Promise<void> {
       ON video_daily(aid, record_date ASC)
     `);
     await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_video_daily_aid_date_desc
+      ON video_daily(aid, record_date DESC)
+      WHERE "view" IS NOT NULL
+    `);
+    await pool.query(`
       SELECT create_hypertable(
         'video_daily',
         by_range('record_date', INTERVAL '90 days'),

--- a/src/database/schema/video_minute.ts
+++ b/src/database/schema/video_minute.ts
@@ -43,6 +43,11 @@ export async function initVideoMinuteSchema(pool: Pool): Promise<void> {
       ON video_minute(aid, "time" ASC)
     `);
     await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_video_minute_aid_time_desc
+      ON video_minute(aid, "time" DESC)
+      WHERE "view" IS NOT NULL
+    `);
+    await pool.query(`
       SELECT create_hypertable(
         'video_minute',
         by_range('time', INTERVAL '90 days'),

--- a/src/services/minute/minuteHandler.ts
+++ b/src/services/minute/minuteHandler.ts
@@ -32,6 +32,7 @@ export class MinuteHandler {
   private poolBuilder = new MinutePoolBuilder();
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private gateRunning = false;
 
   start(): void {
     if (this.timer) return;
@@ -61,10 +62,10 @@ export class MinuteHandler {
 
     this.running = true;
     try {
-      const enqueued = await this.poolBuilder.enqueueDueTasks();
-      if (enqueued.minute > 0 || enqueued.gate > 0) {
+      const enqueuedMinute = await this.poolBuilder.enqueueDueMinuteTasks();
+      if (enqueuedMinute > 0) {
         logger.info(
-          `Minute handler enqueued tasks: minute=${enqueued.minute}, gate=${enqueued.gate}`,
+          `Minute handler enqueued minute tasks: minute=${enqueuedMinute}`,
         );
       }
 
@@ -72,13 +73,36 @@ export class MinuteHandler {
         config.minute.claimBatchSize,
         config.minute.lockDurationSeconds,
       );
-      if (tasks.length === 0) return;
+      if (tasks.length > 0) {
+        await this.processTasks(tasks);
+      }
 
-      await this.processTasks(tasks);
+      void this.enqueueGateTasks();
     } catch (error) {
       logger.error("Minute handler tick failed:", error);
     } finally {
       this.running = false;
+    }
+  }
+
+  private async enqueueGateTasks(): Promise<void> {
+    if (this.gateRunning) {
+      logger.debug(
+        "Minute gate enqueue skipped because previous run is active",
+      );
+      return;
+    }
+
+    this.gateRunning = true;
+    try {
+      const enqueuedGate = await this.poolBuilder.enqueueGateTasks();
+      if (enqueuedGate > 0) {
+        logger.info(`Minute handler enqueued gate tasks: gate=${enqueuedGate}`);
+      }
+    } catch (error) {
+      logger.error("Minute gate enqueue failed:", error);
+    } finally {
+      this.gateRunning = false;
     }
   }
 

--- a/src/services/minute/poolBuilder.ts
+++ b/src/services/minute/poolBuilder.ts
@@ -8,17 +8,19 @@ export class MinutePoolBuilder {
     return this.db.refreshVideoCollectionStateFromDaily(aids);
   }
 
-  async enqueueDueTasks(): Promise<{ minute: number; gate: number }> {
-    const minute = await this.db.enqueueVideoCollectionTasks(
+  async enqueueDueMinuteTasks(): Promise<number> {
+    return this.db.enqueueVideoCollectionTasks(
       new Date(),
       config.minute.maxAttempts,
     );
-    const gate = await this.db.enqueueVideoCollectionGateTasks(new Date(), {
+  }
+
+  async enqueueGateTasks(): Promise<number> {
+    return this.db.enqueueVideoCollectionGateTasks(new Date(), {
       gateLeadTimeMinutes: config.minute.gateLeadTimeMinutes,
       gateMinLeadRatio: config.minute.gateMinLeadRatio,
       gateMaxLeadViews: config.minute.gateMaxLeadViews,
       maxAttempts: config.minute.maxAttempts,
     });
-    return { minute, gate };
   }
 }


### PR DESCRIPTION
## Summary

- let the minute handler enqueue and claim minute tasks before starting gate enqueue work
- run gate enqueue in a guarded background path so a slow gate query does not block future minute ticks
- narrow gate candidates and skip AIDs with active gate tasks
- add supporting indexes for queue claim order and recent daily/minute sample lookups

## Root cause

`fn_enqueue_video_collection_gate_tasks()` can run for minutes across thousands of active state rows. The handler awaited gate enqueue before claiming queued minute tasks, so due minute tasks stayed pending with `attempt_count = 0` and no `video_minute` rows were written.

## Validation

- `pnpm exec biome check src/database/schema/collection_queue.ts src/database/schema/video_daily.ts src/database/schema/video_minute.ts src/services/minute/minuteHandler.ts src/services/minute/poolBuilder.ts`
- `git diff --check`
- `pnpm build`