### PR TITLE
fix: handle missing forwarded dynamics

### DIFF
--- a/src/api/dynamic.ts
+++ b/src/api/dynamic.ts
@@ -32,7 +32,7 @@ const fetchDynamicsAPI = async (
 const fetchDynamicAPI = async (
   endpoint: string,
   params: Record<string, string | number | bigint>,
-): Promise<BiliDynamicDetailResponse> => {
+): Promise<BiliDynamicDetailResponse | null> => {
   try {
     const response = await dynamicDetailClient.get<BiliDynamicDetailResponse>(
       endpoint,
@@ -42,6 +42,10 @@ const fetchDynamicAPI = async (
     );
     return response.data;
   } catch (error) {
+    if (isHttpNotFound(error)) {
+      return null;
+    }
+
     logger.error("API Error:", error);
     if (error instanceof Error) {
       logger.error(error.stack);
@@ -49,6 +53,14 @@ const fetchDynamicAPI = async (
     throw new Error("API Error: Fetch dynamic detail failed");
   }
 };
+
+function isHttpNotFound(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  return "code" in error && error.code === 404;
+}
 
 export const getNewDynamic = (
   type: number,

--- a/src/services/details.service.ts
+++ b/src/services/details.service.ts
@@ -205,6 +205,12 @@ export class DetailsService {
       }
 
       const response = await getDynamic(originalDynamicId);
+      if (!response) {
+        logger.info(
+          `Original dynamic ${originalDynamicId} for forward ${dynamicId} is unavailable (HTTP 404), skipping`,
+        );
+        return "";
+      }
 
       if (response.code !== 0 || !response.data.card?.desc) {
         logger.warn(`Failed to fetch original dynamic ${originalDynamicId}`);


### PR DESCRIPTION
## Summary
- Treat HTTP 404 from the dynamic detail endpoint as an unavailable forwarded dynamic instead of an API failure.
- Return null from getDynamic for detail 404s and have resolveForward skip that forward with an info log.
- Keep other dynamic detail errors on the existing error path.

## Root cause
Bilibili can return an HTML 404 page for deleted or unavailable forwarded dynamics. The Axios response interceptor wrapped that HTTP 404 as an error object, fetchDynamicAPI logged it as an API error, and resolveForward logged another error before skipping. The page processing survived, but the expected unavailable-forward case was reported as an error.

## Validation
- pnpm run check
- pnpm exec tsc --noEmit
- pnpm run build