### PR TITLE
fix: videominute

### DIFF
--- a/src/database/videoMinute.ts
+++ b/src/database/videoMinute.ts
@@ -2,44 +2,6 @@ import type { Pool } from "pg";
 import type { VideoMinuteSample } from "../types/models/minute.js";
 
 const INSERT_VIDEO_MINUTE_SQL = `
-  WITH incoming AS (
-    SELECT *
-    FROM unnest(
-      $1::timestamptz[],
-      $2::bigint[],
-      $3::integer[],
-      $4::integer[],
-      $5::integer[],
-      $6::integer[],
-      $7::integer[],
-      $8::integer[],
-      $9::integer[]
-    ) AS t(
-      "time",
-      aid,
-      coin,
-      favorite,
-      danmaku,
-      "view",
-      reply,
-      share,
-      "like"
-    )
-  ),
-  deduped AS (
-    SELECT DISTINCT ON (aid, "time")
-      "time",
-      aid,
-      coin,
-      favorite,
-      danmaku,
-      "view",
-      reply,
-      share,
-      "like"
-    FROM incoming
-    ORDER BY aid, "time"
-  )
   INSERT INTO video_minute (
     "time",
     aid,
@@ -51,23 +13,38 @@ const INSERT_VIDEO_MINUTE_SQL = `
     share,
     "like"
   )
-  SELECT
-    d."time",
-    d.aid,
-    d.coin,
-    d.favorite,
-    d.danmaku,
-    d."view",
-    d.reply,
-    d.share,
-    d."like"
-  FROM deduped d
-  WHERE NOT EXISTS (
-    SELECT 1
-    FROM video_minute vm
-    WHERE vm.aid = d.aid
-      AND vm."time" = d."time"
+  SELECT DISTINCT ON (aid, "time")
+    "time",
+    aid,
+    coin,
+    favorite,
+    danmaku,
+    "view",
+    reply,
+    share,
+    "like"
+  FROM unnest(
+    $1::timestamptz[],
+    $2::bigint[],
+    $3::integer[],
+    $4::integer[],
+    $5::integer[],
+    $6::integer[],
+    $7::integer[],
+    $8::integer[],
+    $9::integer[]
+  ) AS t(
+    "time",
+    aid,
+    coin,
+    favorite,
+    danmaku,
+    "view",
+    reply,
+    share,
+    "like"
   )
+  ORDER BY aid, "time"
 `;
 
 function sampleParams(samples: VideoMinuteSample[]): unknown[] {


### PR DESCRIPTION
This pull request refactors the SQL used for inserting video minute samples in `src/database/videoMinute.ts`. The main change is a simplification of the SQL logic: instead of using Common Table Expressions (CTEs) for deduplication and filtering, the code now directly inserts data using `unnest`, ordering by `aid` and `time`.

**SQL query simplification and performance:**

* Replaced the use of CTEs (`incoming` and `deduped`) with a direct `INSERT INTO ... SELECT FROM unnest(...)` statement, removing the explicit deduplication and existence check logic. [[1]](diffhunk://#diff-9d91e33dcddf699056c2f8701d1274b995ecbd51c21c7759f2d42c91750ab8a9L5-R5) [[2]](diffhunk://#diff-9d91e33dcddf699056c2f8701d1274b995ecbd51c21c7759f2d42c91750ab8a9L28-L29) [[3]](diffhunk://#diff-9d91e33dcddf699056c2f8701d1274b995ecbd51c21c7759f2d42c91750ab8a9L40-R36) [[4]](diffhunk://#diff-9d91e33dcddf699056c2f8701d1274b995ecbd51c21c7759f2d42c91750ab8a9L54-R47)
* The new query orders inserted rows by `aid` and `time`, but does not perform the previous deduplication or existence check against the `video_minute` table.

This change streamlines the insertion process, but note that it may allow duplicate entries if not otherwise constrained by the database schema.