### PR TITLE
chore: release v5.0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.toml
 node_modules/*
+.pnpm-store/
 *.env
 *.csv
 *.state

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.5
+
+perf: avoid cross-chunk anti-join when inserting video minute samples
+
 ## 5.0.4
 
 fix: avoid pg connect-hook search_path query race

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bilibili-dynamic-subscribe",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build src/index.ts -o dist",


### PR DESCRIPTION
## What changed

- Bump package version to 5.0.5.
- Add changelog entry for the video_minute insert optimization already merged in #15.
- Ignore local pnpm store artifacts generated during verification.

## Why

The production investigation found that the old video_minute insert path planned a cross-chunk anti-join across compressed Timescale chunks. PR #15 removed that hot query shape; this PR prepares the release metadata.

## Verification

- pnpm install
- pnpm check
- pnpm build
