### PR TITLE
perf: batch minute sampling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.6
+
+perf: batch non-gate minute sampling while preserving near-gate latency
+
 ## 5.0.5
 
 perf: avoid cross-chunk anti-join when inserting video minute samples

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bilibili-dynamic-subscribe",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build src/index.ts -o dist",

--- a/src/database/collectionState.ts
+++ b/src/database/collectionState.ts
@@ -113,9 +113,11 @@ export async function selectDueMinuteVideos(
   pool: Pool,
   limit = 50,
   now = new Date(),
-): Promise<{ aid: bigint; lastView: bigint | null }[]> {
+): Promise<
+  { aid: bigint; lastView: bigint | null; nearGate: boolean; dueAt: Date }[]
+> {
   const result = await pool.query(
-    "SELECT aid, last_view FROM fn_select_due_minute_videos($1, $2)",
+    "SELECT aid, last_view, near_gate, due_at FROM fn_select_due_minute_videos($1, $2)",
     [now, limit],
   );
   return result.rows.map((row: Record<string, unknown>) => ({
@@ -124,6 +126,8 @@ export async function selectDueMinuteVideos(
       row.last_view === null || row.last_view === undefined
         ? null
         : BigInt(row.last_view as string | number),
+    nearGate: row.near_gate as boolean,
+    dueAt: new Date(row.due_at as string | number),
   }));
 }
 

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -369,7 +369,9 @@ export class Database {
   public async selectDueMinuteVideos(
     limit?: number,
     now?: Date,
-  ): Promise<{ aid: bigint; lastView: bigint | null }[]> {
+  ): Promise<
+    { aid: bigint; lastView: bigint | null; nearGate: boolean; dueAt: Date }[]
+  > {
     return selectDueMinuteVideos(this.ensurePool(), limit, now);
   }
 

--- a/src/database/schema/collection_state.ts
+++ b/src/database/schema/collection_state.ts
@@ -526,8 +526,8 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
     $$ LANGUAGE plpgsql
   `);
 
-  // For the dynamic-sleep handler loop: find the nearest due time.
-  // Returns NULL if no active videos exist.
+  // For the dynamic-sleep handler loop: find the nearest *future* due time.
+  // Returns NULL if no active videos exist (or all are already past-due).
   await pool.query(`
     CREATE OR REPLACE FUNCTION fn_next_minute_due_at(
       p_now timestamptz DEFAULT now()
@@ -536,6 +536,7 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
       FROM video_collection_state
       WHERE priority > 0
         AND next_minute_due_at IS NOT NULL
+        AND next_minute_due_at > p_now
     $$ LANGUAGE sql STABLE
   `);
 
@@ -543,15 +544,19 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
   // Replaces the enqueue→claim→ack/fail cycle on video_collection_queue.
   // Single consumer + reactive gate triggers make the queue unnecessary.
 
-  // Select videos due for minute sampling. Returns (aid, last_view) for
-  // handler-side dedup (skip INSERT when view count hasn't changed).
-  // Single-consumer architecture: no row locking (FOR UPDATE SKIP LOCKED)
-  // needed — only one handler instance runs at a time.
+  // Select videos due for minute sampling.
+  // Returns (aid, last_view, near_gate, due_at) — the handler uses near_gate
+  // and due_at to implement batch-accumulation: non-gate videos are held
+  // until the batch is full (50), 30 s have elapsed, or a gate video appears.
+  // Single-consumer architecture: no row locking needed.
+  await pool.query(`
+    DROP FUNCTION IF EXISTS fn_select_due_minute_videos(timestamptz, integer)
+  `);
   await pool.query(`
     CREATE OR REPLACE FUNCTION fn_select_due_minute_videos(
       p_now timestamptz DEFAULT now(),
       p_limit integer DEFAULT 50
-    ) RETURNS TABLE (aid bigint, last_view bigint) AS $$
+    ) RETURNS TABLE (aid bigint, last_view bigint, near_gate boolean, due_at timestamptz) AS $$
     BEGIN
       -- Expire bootstrap entries that never got daily data
       UPDATE video_collection_state
@@ -566,7 +571,18 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
         AND weekly_avg_daily_delta IS NULL;
 
       RETURN QUERY
-      SELECT s.aid, s.last_view
+      SELECT s.aid, s.last_view,
+        -- A video is "near gate" (time-critical) when its actual polling
+        -- interval has been compressed below 60 s by gate-proximity
+        -- acceleration or burst-mode scheduling.  The 60 s threshold means
+        -- the 30 s batch timeout would exceed 50 % of the interval.
+        -- First-ever samples (last_minute_success_at IS NULL) are never
+        -- time-critical: they have no acceleration history.
+        (s.last_minute_success_at IS NOT NULL
+          AND extract(epoch from s.next_minute_due_at - s.last_minute_success_at)
+            BETWEEN 0 AND 60
+        ) AS near_gate,
+        s.next_minute_due_at AS due_at
       FROM video_collection_state s
       WHERE s.priority > 0
         AND s.next_minute_due_at IS NOT NULL

--- a/src/services/minute/minuteHandler.ts
+++ b/src/services/minute/minuteHandler.ts
@@ -6,6 +6,8 @@ import { batchSampleVideoStats } from "./batchSampleVideoStats";
 
 const MAX_SLEEP_MS = 60_000;
 const MIN_SLEEP_MS = 100;
+/** Non-gate videos wait at most this long before being flushed. */
+const BATCH_TIMEOUT_MS = 30_000;
 
 function cancellableSleep(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
@@ -32,7 +34,7 @@ export class MinuteHandler {
     this.isRunning = true;
     this.abortController = new AbortController();
     this.loopPromise = this.loop(this.abortController.signal);
-    logger.info("Adaptive minute handler started (dynamic sleep)");
+    logger.info("Adaptive minute handler started (batch-accumulation)");
   }
 
   async stop(): Promise<void> {
@@ -47,27 +49,78 @@ export class MinuteHandler {
   }
 
   /**
-   * Main loop: process due aids, then sleep until the next due time.
-   * No fixed tick interval — wakes exactly when the next video is due.
-   * Single-consumer by design — no row locking needed.
+   * Main loop with batch-accumulation.
+   *
+   * Non-gate videos are held until one of three flush triggers fires:
+   *   1. A near-gate video appears among the due set
+   *   2. The due set reaches {@link config.minute.claimBatchSize} (SELECT limit)
+   *   3. The earliest pending video is overdue by ≥ {@link BATCH_TIMEOUT_MS}
+   *
+   * Gate videos cause an immediate flush of the entire due set (including any
+   * non-gate videos that have accumulated), so gate latency stays minimal.
    */
   private async loop(signal: AbortSignal): Promise<void> {
     while (this.isRunning) {
       try {
-        const processed = await this.tick();
-        if (processed > 0) {
+        const due = await this.db.selectDueMinuteVideos(
+          config.minute.claimBatchSize,
+        );
+
+        // ── Nothing due — sleep until the next video becomes due ──
+        if (due.length === 0) {
+          const nextDue = await this.db.getNextMinuteDueAt();
+          const now = Date.now();
+          const waitMs = nextDue
+            ? Math.max(
+                Math.min(nextDue.getTime() - now, MAX_SLEEP_MS),
+                MIN_SLEEP_MS,
+              )
+            : MAX_SLEEP_MS;
+          await cancellableSleep(waitMs, signal);
           continue;
         }
 
-        const nextDue = await this.db.getNextMinuteDueAt();
-        const now = Date.now();
-        const waitMs = nextDue
-          ? Math.max(
-              Math.min(nextDue.getTime() - now, MAX_SLEEP_MS),
-              MIN_SLEEP_MS,
-            )
-          : MAX_SLEEP_MS;
-        await cancellableSleep(waitMs, signal);
+        // ── Evaluate flush triggers ──
+        const hasGate = due.some((d) => d.nearGate);
+        const isFull = due.length >= config.minute.claimBatchSize;
+        const earliestDueAt = Math.min(...due.map((d) => d.dueAt.getTime()));
+        const overdueLongEnough =
+          Date.now() - earliestDueAt >= BATCH_TIMEOUT_MS;
+
+        if (hasGate || isFull || overdueLongEnough) {
+          if (hasGate) {
+            logger.debug(`Minute batch flush: gate (${due.length} video(s))`);
+          } else if (isFull) {
+            logger.debug(
+              `Minute batch flush: full batch (${due.length} video(s))`,
+            );
+          } else {
+            logger.debug(
+              `Minute batch flush: timeout (${due.length} video(s), ` +
+                `waited ${Math.round((Date.now() - earliestDueAt) / 1000)}s)`,
+            );
+          }
+
+          await this.processBatch(due);
+          // Immediately re-check — there may be more due videos.
+          continue;
+        }
+
+        // ── Not ready to flush — sleep until timeout or next due ──
+        const timeUntilTimeout =
+          BATCH_TIMEOUT_MS - (Date.now() - earliestDueAt);
+        const nextFutureDue = await this.db.getNextMinuteDueAt();
+
+        let sleepMs = timeUntilTimeout;
+        if (nextFutureDue) {
+          const timeUntilNextDue = nextFutureDue.getTime() - Date.now();
+          if (timeUntilNextDue > 0 && timeUntilNextDue < sleepMs) {
+            sleepMs = timeUntilNextDue;
+          }
+        }
+
+        sleepMs = Math.max(Math.min(sleepMs, MAX_SLEEP_MS), MIN_SLEEP_MS);
+        await cancellableSleep(sleepMs, signal);
       } catch (error) {
         logger.error("Minute handler loop error:", error);
         await cancellableSleep(5_000, signal);
@@ -76,10 +129,13 @@ export class MinuteHandler {
     this.loopPromise = null;
   }
 
-  private async tick(): Promise<number> {
-    const due = await this.db.selectDueMinuteVideos(
-      config.minute.claimBatchSize,
-    );
+  /**
+   * Fetch stats for a pre-selected set of due videos, diff against last_view,
+   * then insert changed samples / advance unchanged / mark failed.
+   */
+  private async processBatch(
+    due: { aid: bigint; lastView: bigint | null }[],
+  ): Promise<number> {
     if (due.length === 0) return 0;
 
     const aids = due.map((d) => d.aid);


### PR DESCRIPTION
## What changed

- Add batch accumulation for non-gate minute sampling.
- Extend `fn_select_due_minute_videos` to return `near_gate` and `due_at` so the handler can decide when to flush.
- Keep near-gate videos on immediate flush while allowing non-gate videos to wait until full batch or 30 seconds.
- Bump release metadata to 5.0.6.

## Why

The tar snapshot included more than the `video_minute` anti-join fix released in v5.0.5. These remaining changes reduce daily database/API churn by batching non-time-critical minute samples while preserving latency for gate-adjacent videos.

## Verification

- git diff --check
- Local `pnpm install` currently hits Windows `spawn EPERM` during esbuild postinstall in this worktree, so GitHub Actions should be used as the full install/check/build/package verification.
