### PR TITLE
feat: add Prometheus metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The application is configured via `config.toml`. Key sections include:
 
 - **[bilibili]**: Authentication (UID, SessData or Cookie File).
 - **[database]**: PostgreSQL connection URL.
+- **[metrics]**: Optional Prometheus `/metrics` endpoint.
 - **[application]**: Execution settings (interval, concurrency, history).
 - **[processing]**: Filter rules and feature flags (recommendations).
 
@@ -78,6 +79,37 @@ file (e.g., exported from browser extensions like "Cookie-Editor"):
 [bilibili]
 uid = "12345678"
 cookie_file = "./.cookies.txt"  # Path to Netscape cookie file
+```
+
+### Prometheus Metrics
+
+Metrics are disabled by default. Enable the built-in Prometheus scrape endpoint
+with a `[metrics]` block or environment variables:
+
+```toml
+[metrics]
+enabled = true
+host = "127.0.0.1"
+port = 9469
+path = "/metrics"
+collect_default_metrics = true
+# auth_token = "change-me"
+```
+
+When `auth_token` is set, scrape requests must include
+`Authorization: Bearer <token>`. The endpoint exports process metrics plus
+application metrics with the `bili_tracker_` prefix for fetch cycles, Bilibili
+API latency and errors, rate limiter depth, PostgreSQL query and pool state,
+adaptive minute sampling, notifications, exports, and fatal exit reasons.
+
+Prometheus scrape example:
+
+```yaml
+scrape_configs:
+  - job_name: bili-tracker
+    scrape_interval: 30s
+    static_configs:
+      - targets: ["127.0.0.1:9469"]
 ```
 
 ## Development

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.0
+
+feat: add optional Prometheus metrics endpoint and instrumentation
+
 ## 5.0.7
 
 perf: floor minute sampling cadence and keep normal scheduling grid-aligned

--- a/config.toml.example
+++ b/config.toml.example
@@ -45,6 +45,15 @@ retrospective_days = 30        # Days to look back during retrospective scan (de
 url = "postgresql://localhost:5432/hantang"  # PostgreSQL connection URL
 schema = "public"                            # PostgreSQL schema name (default: public)
 
+[metrics]
+# Prometheus metrics endpoint (disabled by default)
+enabled = false
+host = "127.0.0.1"                 # Use "0.0.0.0" when scraping from outside the container/host
+port = 9469
+path = "/metrics"
+collect_default_metrics = true
+# auth_token = "change-me"         # Requires Authorization: Bearer <token>
+
 [minute]
 # Adaptive minute collection with progressive gate-approach acceleration.
 # Handler uses dynamic sleep (wakes at next due time), no fixed tick interval.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bilibili-dynamic-subscribe",
-  "version": "5.0.7",
+  "version": "5.1.0",
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build src/index.ts -o dist",
@@ -26,6 +26,7 @@
     "mysql2": "^3.22.3",
     "nodemailer": "^8.0.8",
     "pg": "^8.21.0",
+    "prom-client": "^15.1.3",
     "smol-toml": "^1.6.1",
     "tough-cookie": "^6.0.1",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       pg:
         specifier: ^8.21.0
         version: 8.21.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       smol-toml:
         specifier: ^1.6.1
         version: 1.6.1
@@ -555,6 +558,10 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@roberts_lando/vfs@0.3.3':
     resolution: {integrity: sha512-YjkxVSLw5WMZQoARaryRAjcxA+GbBzWMJdwYZX5oLUt9cC/gew9as4Dn7tcLzPp7BPoR221VpTZ+78TRPawnjg==}
     engines: {node: '>= 22'}
@@ -671,6 +678,9 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -1089,6 +1099,10 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -1196,6 +1210,9 @@ packages:
   tar@7.5.15:
     resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
     engines: {node: '>=18'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -1584,6 +1601,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@roberts_lando/vfs@0.3.3': {}
 
   '@types/cli-progress@3.11.6':
@@ -1723,6 +1742,8 @@ snapshots:
       bare-path: 3.0.0
 
   base64-js@1.5.1: {}
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -2139,6 +2160,11 @@ snapshots:
 
   progress@2.0.3: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
@@ -2282,6 +2308,10 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   teex@1.0.1:
     dependencies:

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -8,6 +8,12 @@ import type { CookieJar } from "tough-cookie";
 import { config } from "../config";
 import { StateManager } from "../core/state";
 import {
+  apiErrorsByCodeTotal,
+  apiRequestDurationSeconds,
+  apiRequestsTotal,
+  fatalExitsTotal,
+} from "../metrics/registry";
+import {
   createCookieJarFromNetscape,
   getAllCookiesAsString,
   parseNetscapeCookieFile,
@@ -38,6 +44,54 @@ enum ApiErrorResponseCode {
 }
 
 const state = new StateManager();
+
+function hostLabel(baseURL: string | undefined): string {
+  if (!baseURL) return "unknown";
+  try {
+    return new URL(baseURL).hostname || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+export function routeLabel(url: string | undefined): string {
+  if (!url) return "unknown";
+
+  let path = url.split("?", 1)[0] || "/";
+  try {
+    path = new URL(url).pathname;
+  } catch {
+    // Relative URLs are expected for project API calls.
+  }
+
+  const normalized = path
+    .split("/")
+    .map((segment) => {
+      if (/^\d+$/.test(segment)) return ":id";
+      if (/^(av|bv)[a-z0-9]+$/i.test(segment)) return ":id";
+      return segment;
+    })
+    .join("/");
+
+  return normalized || "/";
+}
+
+function recordApiRequest(
+  baseURL: string | undefined,
+  url: string | undefined,
+  result: "success" | "error" | "retry",
+  durationMs?: number,
+): void {
+  const labels = {
+    host: hostLabel(baseURL),
+    route: routeLabel(url),
+  };
+
+  apiRequestsTotal.inc({ ...labels, result });
+  if (durationMs !== undefined && durationMs >= 0) {
+    apiRequestDurationSeconds.observe(labels, durationMs / 1000);
+  }
+}
 
 // Singleton cookie jar manager for cookie file support
 let globalCookieJar: CookieJar | null = null;
@@ -188,6 +242,9 @@ function createClient(
       );
 
       if (response.status === ApiErrorResponseCode.IpBanned) {
+        recordApiRequest(baseURL, response.config.url, "error", timeUsed);
+        apiErrorsByCodeTotal.inc({ code: String(response.status) });
+        fatalExitsTotal.inc({ reason: "ip_ban" });
         const message =
           "CRITICAL ERROR: IP has been banned! Terminating process.";
         logger.error(`${message}致命错误：IP·被封禁！正在终止进程。`);
@@ -204,6 +261,8 @@ function createClient(
         response.data.code !== 62002 &&
         response.data.code !== 62004
       ) {
+        recordApiRequest(baseURL, response.config.url, "error", timeUsed);
+        apiErrorsByCodeTotal.inc({ code: String(response.data.code) });
         const message =
           `API Error:\n` +
           `Code: ${response.data.code}\n` +
@@ -220,6 +279,7 @@ function createClient(
         }
 
         if (response.data.code === ApiErrorCode.CookieExpired) {
+          fatalExitsTotal.inc({ reason: "cookie_expired" });
           logger.error(
             "CRITICAL ERROR: Cookie has expired! Authentication required. Terminating process.\n" +
               "致命错误：Cookie 已过期！请重新登录。正在终止进程。",
@@ -228,6 +288,7 @@ function createClient(
         }
 
         if (response.data.code === ApiErrorCode.RiskControlFailed) {
+          fatalExitsTotal.inc({ reason: "risk_control" });
           logger.error(
             "CRITICAL ERROR: Risk control failed! Terminating process.\n" +
               "致命错误：风控失败！正在终止进程。",
@@ -246,16 +307,35 @@ function createClient(
         persistJar();
       }
 
+      recordApiRequest(baseURL, response.config.url, "success", timeUsed);
       return response;
     },
     async (error) => {
+      const errorConfig = error.config as RequestConfig | undefined;
+      const startTime = errorConfig?.metadata?.startTime ?? Date.now();
+      const durationMs = Date.now() - startTime;
+      const status = error.response?.status;
+
+      if (status === ApiErrorResponseCode.IpBanned) {
+        recordApiRequest(baseURL, errorConfig?.url, "error", durationMs);
+        apiErrorsByCodeTotal.inc({ code: String(status) });
+        fatalExitsTotal.inc({ reason: "ip_ban" });
+        const message =
+          "CRITICAL ERROR: IP has been banned! Terminating process.";
+        logger.error(`${message}致命错误：IP·被封禁！正在终止进程。`);
+        await notifyWarning(message);
+        process.exit(2);
+      }
+
       if (!error.response || error.response.status === 524) {
+        recordApiRequest(baseURL, errorConfig?.url, "retry", durationMs);
         return retryDelay(
           () => client(error.config),
           config.application.apiRetryTimes,
           config.application.apiWaitTime,
         );
       }
+      recordApiRequest(baseURL, errorConfig?.url, "error", durationMs);
       return Promise.reject({
         message: error.message,
         code: error.response?.status,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,11 +9,13 @@ import {
   createBilibiliConfig,
   createDatabaseConfig,
   createExportConfig,
+  createMetricsConfig,
   createMinuteConfig,
   createNotificationsConfig,
   createProcessingConfig,
   databaseSchema,
   exportSchema,
+  metricsSchema,
   minuteSchema,
   notificationsSchema,
   processingSchema,
@@ -77,6 +79,7 @@ const configSchema = z.object({
   minute: minuteSchema,
   processing: processingSchema,
   export: exportSchema,
+  metrics: metricsSchema,
   notifications: notificationsSchema,
 });
 
@@ -87,5 +90,6 @@ export const config = configSchema.parse({
   minute: createMinuteConfig(getConfigValue),
   processing: createProcessingConfig(getConfigValue),
   export: createExportConfig(getConfigValue),
+  metrics: createMetricsConfig(getConfigValue),
   notifications: createNotificationsConfig(getConfigValue),
 });

--- a/src/config/schemas/index.ts
+++ b/src/config/schemas/index.ts
@@ -2,6 +2,7 @@ export { applicationSchema, createApplicationConfig } from "./application";
 export { bilibiliSchema, createBilibiliConfig } from "./bilibili";
 export { createDatabaseConfig, databaseSchema } from "./database";
 export { createExportConfig, exportSchema } from "./export";
+export { createMetricsConfig, metricsSchema } from "./metrics";
 export { createMinuteConfig, minuteSchema } from "./minute";
 export {
   createNotificationsConfig,

--- a/src/config/schemas/metrics.ts
+++ b/src/config/schemas/metrics.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+const configBoolean = z.preprocess((value) => {
+  if (typeof value !== "string") return value;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}, z.boolean());
+
+export const metricsSchema = z.object({
+  enabled: configBoolean.default(false),
+  host: z.string().default("127.0.0.1"),
+  port: z.coerce.number().int().positive().default(9469),
+  path: z.string().startsWith("/").default("/metrics"),
+  collectDefaultMetrics: configBoolean.default(true),
+  authToken: z.string().optional(),
+});
+
+export type MetricsConfig = z.infer<typeof metricsSchema>;
+
+export function createMetricsConfig(
+  getConfigValue: (
+    tomlPath: string[],
+    envKey: string,
+    // biome-ignore lint/suspicious/noExplicitAny: Config values from TOML/env are inherently untyped and validated by zod
+    defaultValue?: any,
+    // biome-ignore lint/suspicious/noExplicitAny: Config values from TOML/env are inherently untyped and validated by zod
+  ) => any,
+): MetricsConfig {
+  return metricsSchema.parse({
+    enabled: getConfigValue(["metrics", "enabled"], "METRICS_ENABLED", false),
+    host: getConfigValue(["metrics", "host"], "METRICS_HOST", "127.0.0.1"),
+    port: getConfigValue(["metrics", "port"], "METRICS_PORT", 9469),
+    path: getConfigValue(["metrics", "path"], "METRICS_PATH", "/metrics"),
+    collectDefaultMetrics: getConfigValue(
+      ["metrics", "collect_default_metrics"],
+      "METRICS_COLLECT_DEFAULT",
+      true,
+    ),
+    authToken: getConfigValue(
+      ["metrics", "auth_token"],
+      "METRICS_AUTH_TOKEN",
+      undefined,
+    ),
+  });
+}

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,5 +1,10 @@
 import { Pool } from "pg";
 import { config } from "../config/index.js";
+import {
+  dbPoolConnections,
+  dbQueryDurationSeconds,
+  dbQueryErrorsTotal,
+} from "../metrics/registry.js";
 import type {
   DatabaseStats,
   DiscoveredUserData,
@@ -20,6 +25,35 @@ import { logger } from "../utils/logger.js";
 
 function quotePostgresIdentifier(identifier: string): string {
   return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function extractSqlText(query: unknown): string {
+  if (typeof query === "string") return query;
+  if (
+    query &&
+    typeof query === "object" &&
+    "text" in query &&
+    typeof query.text === "string"
+  ) {
+    return query.text;
+  }
+  return "";
+}
+
+function queryOperationLabel(query: unknown): string {
+  const sql = extractSqlText(query)
+    .replace(/--.*$/gm, " ")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .trim()
+    .toLowerCase();
+
+  const keyword = sql.match(/^[a-z]+/)?.[0] ?? "unknown";
+  const tableMatch = sql.match(
+    /\b(?:from|into|update|join|table|index on)\s+("?[\w.]+"?)/,
+  );
+  const table = tableMatch?.[1]?.replace(/"/g, "") ?? "";
+
+  return table ? `${keyword} ${table}` : keyword;
 }
 
 // Import operation modules
@@ -67,6 +101,7 @@ import {
 export class Database {
   private static instance: Database | null = null;
   private pool: Pool | null = null;
+  private poolMetricsTimer: NodeJS.Timeout | null = null;
 
   private constructor() {}
 
@@ -111,6 +146,8 @@ export class Database {
         // A pool "connect" hook cannot be awaited and can race the first query.
         options: `-c search_path=${quotePostgresIdentifier(schema)}`,
       });
+      this.wrapPoolQuery(this.pool);
+      this.startPoolMetricsSampler(this.pool);
 
       // Test connection
       const client = await this.pool.connect();
@@ -135,6 +172,55 @@ export class Database {
       throw new Error("Database not initialized");
     }
     return this.pool;
+  }
+
+  private wrapPoolQuery(pool: Pool): void {
+    const originalQuery = pool.query.bind(pool) as (
+      ...args: unknown[]
+    ) => unknown;
+
+    pool.query = ((...args: unknown[]): unknown => {
+      const callbackCandidate = args[args.length - 1];
+      if (typeof callbackCandidate === "function") {
+        return originalQuery(...args);
+      }
+
+      const operation = queryOperationLabel(args[0]);
+      const endQuery = dbQueryDurationSeconds.startTimer({ operation });
+
+      try {
+        const result = originalQuery(...args);
+        if (result && typeof (result as Promise<unknown>).then === "function") {
+          return (result as Promise<unknown>)
+            .catch((error) => {
+              dbQueryErrorsTotal.inc({ operation });
+              throw error;
+            })
+            .finally(() => {
+              endQuery();
+            });
+        }
+
+        endQuery();
+        return result;
+      } catch (error) {
+        dbQueryErrorsTotal.inc({ operation });
+        endQuery();
+        throw error;
+      }
+    }) as Pool["query"];
+  }
+
+  private startPoolMetricsSampler(pool: Pool): void {
+    const sample = () => {
+      dbPoolConnections.set({ state: "total" }, pool.totalCount);
+      dbPoolConnections.set({ state: "idle" }, pool.idleCount);
+      dbPoolConnections.set({ state: "waiting" }, pool.waitingCount);
+    };
+
+    sample();
+    this.poolMetricsTimer = setInterval(sample, 15_000);
+    this.poolMetricsTimer.unref();
   }
 
   // ===== Video Operations =====
@@ -401,6 +487,10 @@ export class Database {
    * Close the database connection pool
    */
   public async close(): Promise<void> {
+    if (this.poolMetricsTimer) {
+      clearInterval(this.poolMetricsTimer);
+      this.poolMetricsTimer = null;
+    }
     if (this.pool) {
       await this.pool.end();
       this.pool = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
 import { config } from "./config";
 import { loadAccounts } from "./core/account";
 import { Database } from "./database";
+import { initializeBuildInfo } from "./metrics/registry";
+import { startMetricsServer, stopMetricsServer } from "./metrics/server";
 import { MinuteHandler } from "./services/minute/minuteHandler";
 import { DynamicTracker } from "./services/tracker";
 import { logger } from "./utils/logger";
+import { APP_VERSION } from "./version";
 
 async function runTracker() {
   logger.info("Starting Bilibili Video Tracker");
@@ -11,6 +14,8 @@ async function runTracker() {
 
   // Initialize Database
   await Database.getInstance().init();
+  initializeBuildInfo(APP_VERSION);
+  await startMetricsServer();
 
   // Load all configured accounts (one per cookie file, or one legacy sessdata account)
   const accounts = loadAccounts();
@@ -29,6 +34,7 @@ async function runTracker() {
       tracker.stop();
     }
     if (minuteHandler) await minuteHandler.stop();
+    await stopMetricsServer();
     try {
       await Database.getInstance().close();
       logger.info("Database connection closed");
@@ -89,6 +95,13 @@ async function main() {
 }
 
 main().catch(async (error) => {
+  try {
+    const { fatalExitsTotal } = await import("./metrics/registry");
+    fatalExitsTotal.inc({ reason: "fatal_error" });
+  } catch (metricsError) {
+    logger.error("Failed to record fatal exit metric:", metricsError);
+  }
+
   const message = `Fatal Error: ${error}\n${
     error instanceof Error ? error.stack : ""
   }`;

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -1,0 +1,172 @@
+import {
+  Counter,
+  collectDefaultMetrics,
+  Gauge,
+  Histogram,
+  Registry,
+} from "prom-client";
+import { config } from "../config";
+import { sharedApiRateLimiter } from "../utils/apiRateLimiter";
+
+const PREFIX = "bili_tracker_";
+
+export const metricsRegistry = new Registry();
+metricsRegistry.setDefaultLabels({ app: "bilibili-dynamic-subscribe" });
+
+if (config.metrics.enabled && config.metrics.collectDefaultMetrics) {
+  collectDefaultMetrics({
+    prefix: PREFIX,
+    register: metricsRegistry,
+  });
+}
+
+export const buildInfo = new Gauge({
+  name: `${PREFIX}build_info`,
+  help: "Build and runtime information for bilibili-dynamic-subscribe.",
+  labelNames: ["version", "node_version"] as const,
+  registers: [metricsRegistry],
+});
+
+export const fetchCyclesTotal = new Counter({
+  name: `${PREFIX}fetch_cycles_total`,
+  help: "Total dynamic fetch cycles.",
+  labelNames: ["uid", "result"] as const,
+  registers: [metricsRegistry],
+});
+
+export const fetchCycleDurationSeconds = new Histogram({
+  name: `${PREFIX}fetch_cycle_duration_seconds`,
+  help: "Dynamic fetch cycle duration in seconds.",
+  labelNames: ["uid"] as const,
+  buckets: [0.5, 1, 2, 5, 10, 30, 60, 120, 300],
+  registers: [metricsRegistry],
+});
+
+export const lastSuccessfulFetchTimestampSeconds = new Gauge({
+  name: `${PREFIX}last_successful_fetch_timestamp_seconds`,
+  help: "Unix timestamp of the last successful dynamic fetch.",
+  labelNames: ["uid"] as const,
+  registers: [metricsRegistry],
+});
+
+export const dynamicsSeenTotal = new Counter({
+  name: `${PREFIX}dynamics_seen_total`,
+  help: "Total dynamic cards seen from Bilibili APIs.",
+  labelNames: ["uid", "type"] as const,
+  registers: [metricsRegistry],
+});
+
+export const videosProcessedTotal = new Counter({
+  name: `${PREFIX}videos_processed_total`,
+  help: "Total newly processed videos.",
+  labelNames: ["uid"] as const,
+  registers: [metricsRegistry],
+});
+
+export const apiRequestsTotal = new Counter({
+  name: `${PREFIX}api_requests_total`,
+  help: "Total Bilibili API requests.",
+  labelNames: ["host", "route", "result"] as const,
+  registers: [metricsRegistry],
+});
+
+export const apiRequestDurationSeconds = new Histogram({
+  name: `${PREFIX}api_request_duration_seconds`,
+  help: "Bilibili API request duration in seconds.",
+  labelNames: ["host", "route"] as const,
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+  registers: [metricsRegistry],
+});
+
+export const apiErrorsByCodeTotal = new Counter({
+  name: `${PREFIX}api_errors_by_code_total`,
+  help: "Total Bilibili API logical errors by response code.",
+  labelNames: ["code"] as const,
+  registers: [metricsRegistry],
+});
+
+export const rateLimiterActive = new Gauge({
+  name: `${PREFIX}rate_limiter_active`,
+  help: "Current active operations in the shared API rate limiter.",
+  registers: [metricsRegistry],
+  collect() {
+    this.set(sharedApiRateLimiter.getActiveCount());
+  },
+});
+
+export const rateLimiterQueued = new Gauge({
+  name: `${PREFIX}rate_limiter_queued`,
+  help: "Current queued operations in the shared API rate limiter.",
+  registers: [metricsRegistry],
+  collect() {
+    this.set(sharedApiRateLimiter.getQueueLength());
+  },
+});
+
+export const dbQueryDurationSeconds = new Histogram({
+  name: `${PREFIX}db_query_duration_seconds`,
+  help: "PostgreSQL query duration in seconds.",
+  labelNames: ["operation"] as const,
+  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
+  registers: [metricsRegistry],
+});
+
+export const dbQueryErrorsTotal = new Counter({
+  name: `${PREFIX}db_query_errors_total`,
+  help: "Total PostgreSQL query errors.",
+  labelNames: ["operation"] as const,
+  registers: [metricsRegistry],
+});
+
+export const dbPoolConnections = new Gauge({
+  name: `${PREFIX}db_pool_connections`,
+  help: "PostgreSQL pool connection counts.",
+  labelNames: ["state"] as const,
+  registers: [metricsRegistry],
+});
+
+export const minuteBatchesTotal = new Counter({
+  name: `${PREFIX}minute_batches_total`,
+  help: "Total adaptive minute batches by trigger.",
+  labelNames: ["trigger"] as const,
+  registers: [metricsRegistry],
+});
+
+export const minuteSamplesTotal = new Counter({
+  name: `${PREFIX}minute_samples_total`,
+  help: "Total adaptive minute samples by outcome.",
+  labelNames: ["outcome"] as const,
+  registers: [metricsRegistry],
+});
+
+export const minuteBatchDurationSeconds = new Histogram({
+  name: `${PREFIX}minute_batch_duration_seconds`,
+  help: "Adaptive minute batch duration in seconds.",
+  buckets: [0.1, 0.5, 1, 2, 5, 10, 30, 60],
+  registers: [metricsRegistry],
+});
+
+export const notificationsTotal = new Counter({
+  name: `${PREFIX}notifications_total`,
+  help: "Total notification attempts by channel and result.",
+  labelNames: ["channel", "result"] as const,
+  registers: [metricsRegistry],
+});
+
+export const exportsTotal = new Counter({
+  name: `${PREFIX}exports_total`,
+  help: "Total export attempts by target and result.",
+  labelNames: ["target", "result"] as const,
+  registers: [metricsRegistry],
+});
+
+export const fatalExitsTotal = new Counter({
+  name: `${PREFIX}fatal_exits_total`,
+  help: "Total fatal process exits by reason.",
+  labelNames: ["reason"] as const,
+  registers: [metricsRegistry],
+});
+
+export function initializeBuildInfo(version: string): void {
+  buildInfo.set({ version, node_version: process.version }, 1);
+}

--- a/src/metrics/server.ts
+++ b/src/metrics/server.ts
@@ -1,0 +1,71 @@
+import { createServer, type Server } from "node:http";
+import { config } from "../config";
+import { logger } from "../utils/logger";
+import { metricsRegistry } from "./registry";
+
+let server: Server | null = null;
+
+export async function startMetricsServer(): Promise<void> {
+  if (!config.metrics.enabled || server) return;
+
+  server = createServer(async (req, res) => {
+    if (req.method !== "GET") {
+      res.statusCode = 405;
+      res.end("Method Not Allowed\n");
+      return;
+    }
+
+    const path = req.url?.split("?", 1)[0] ?? "/";
+    if (path !== config.metrics.path) {
+      res.statusCode = 404;
+      res.end("Not Found\n");
+      return;
+    }
+
+    if (config.metrics.authToken) {
+      const expected = `Bearer ${config.metrics.authToken}`;
+      if (req.headers.authorization !== expected) {
+        res.statusCode = 401;
+        res.end("Unauthorized\n");
+        return;
+      }
+    }
+
+    try {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", metricsRegistry.contentType);
+      res.end(await metricsRegistry.metrics());
+    } catch (error) {
+      logger.error("Failed to render Prometheus metrics:", error);
+      res.statusCode = 500;
+      res.end("Internal Server Error\n");
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const activeServer = server;
+    if (!activeServer) return reject(new Error("Metrics server missing"));
+    activeServer.once("error", reject);
+    activeServer.listen(config.metrics.port, config.metrics.host, () => {
+      activeServer.off("error", reject);
+      activeServer.unref();
+      resolve();
+    });
+  });
+
+  logger.info(
+    `Prometheus metrics listening on http://${config.metrics.host}:${config.metrics.port}${config.metrics.path}`,
+  );
+}
+
+export async function stopMetricsServer(): Promise<void> {
+  if (!server) return;
+  const activeServer = server;
+  server = null;
+  await new Promise<void>((resolve, reject) => {
+    activeServer.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}

--- a/src/services/minute/minuteHandler.ts
+++ b/src/services/minute/minuteHandler.ts
@@ -1,5 +1,10 @@
 import { config } from "../../config";
 import { Database } from "../../database";
+import {
+  minuteBatchDurationSeconds,
+  minuteBatchesTotal,
+  minuteSamplesTotal,
+} from "../../metrics/registry";
 import type { VideoMinuteSample } from "../../types/models/minute";
 import { logger } from "../../utils/logger";
 import { batchSampleVideoStats } from "./batchSampleVideoStats";
@@ -87,6 +92,8 @@ export class MinuteHandler {
         const waitedLongEnough = Date.now() - earliestDueAt >= BATCH_TIMEOUT_MS;
 
         if (hasGate || isFull || waitedLongEnough) {
+          const trigger = hasGate ? "gate" : isFull ? "full" : "timeout";
+          minuteBatchesTotal.inc({ trigger });
           if (hasGate) {
             logger.debug(`Minute batch flush: gate (${due.length} video(s))`);
           } else if (isFull) {
@@ -136,6 +143,7 @@ export class MinuteHandler {
     due: { aid: bigint; lastView: bigint | null }[],
   ): Promise<number> {
     if (due.length === 0) return 0;
+    const endBatch = minuteBatchDurationSeconds.startTimer();
 
     const aids = due.map((d) => d.aid);
     const lastViewByAid = new Map(
@@ -144,56 +152,78 @@ export class MinuteHandler {
 
     let samples: VideoMinuteSample[] = [];
     try {
-      samples = await batchSampleVideoStats(aids, {
-        batchSize: config.minute.batchSize,
-      });
-    } catch (error) {
-      logger.error("Minute stats batch request failed:", error);
-      await this.db.advanceFailedMinuteVideos(aids);
-      return aids.length;
-    }
-
-    const changed: VideoMinuteSample[] = [];
-    const unchangedAids: bigint[] = [];
-    const sampledAidSet = new Set<string>();
-
-    for (const sample of samples) {
-      const key = sample.aid.toString();
-      // Skip samples with missing view — inserting NULL view would overwrite
-      // last_view and break near-gate scheduling. Let it fall to failedAids.
-      if (sample.view === null || sample.view === undefined) {
-        continue;
-      }
-      sampledAidSet.add(key);
-      const prev = lastViewByAid.get(key);
-      if (prev === null || prev === undefined || BigInt(sample.view) !== prev) {
-        changed.push(sample);
-      } else {
-        unchangedAids.push(sample.aid);
-      }
-    }
-
-    const failedAids = aids.filter((aid) => !sampledAidSet.has(aid.toString()));
-
-    if (changed.length > 0) {
       try {
-        await this.db.insertVideoMinuteSamples(changed);
+        samples = await batchSampleVideoStats(aids, {
+          batchSize: config.minute.batchSize,
+        });
       } catch (error) {
-        logger.error("Minute sample write failed:", error);
+        logger.error("Minute stats batch request failed:", error);
+        minuteSamplesTotal.inc({ outcome: "failed" }, aids.length);
         await this.db.advanceFailedMinuteVideos(aids);
         return aids.length;
       }
-    }
 
-    if (unchangedAids.length > 0) {
-      await this.db.advanceUnchangedMinuteVideos(unchangedAids);
-    }
+      const changed: VideoMinuteSample[] = [];
+      const unchangedAids: bigint[] = [];
+      const sampledAidSet = new Set<string>();
 
-    if (failedAids.length > 0) {
-      logger.warn(`Minute stats response missed ${failedAids.length} aid(s)`);
-      await this.db.advanceFailedMinuteVideos(failedAids);
-    }
+      for (const sample of samples) {
+        const key = sample.aid.toString();
+        // Skip samples with missing view — inserting NULL view would overwrite
+        // last_view and break near-gate scheduling. Let it fall to failedAids.
+        if (sample.view === null || sample.view === undefined) {
+          continue;
+        }
+        sampledAidSet.add(key);
+        const prev = lastViewByAid.get(key);
+        if (
+          prev === null ||
+          prev === undefined ||
+          BigInt(sample.view) !== prev
+        ) {
+          changed.push(sample);
+        } else {
+          unchangedAids.push(sample.aid);
+        }
+      }
 
-    return aids.length;
+      const failedAids = aids.filter(
+        (aid) => !sampledAidSet.has(aid.toString()),
+      );
+
+      if (changed.length > 0) {
+        try {
+          await this.db.insertVideoMinuteSamples(changed);
+        } catch (error) {
+          logger.error("Minute sample write failed:", error);
+          minuteSamplesTotal.inc({ outcome: "failed" }, aids.length);
+          await this.db.advanceFailedMinuteVideos(aids);
+          return aids.length;
+        }
+      }
+
+      if (unchangedAids.length > 0) {
+        await this.db.advanceUnchangedMinuteVideos(unchangedAids);
+      }
+
+      if (failedAids.length > 0) {
+        logger.warn(`Minute stats response missed ${failedAids.length} aid(s)`);
+        await this.db.advanceFailedMinuteVideos(failedAids);
+      }
+
+      if (changed.length > 0) {
+        minuteSamplesTotal.inc({ outcome: "changed" }, changed.length);
+      }
+      if (unchangedAids.length > 0) {
+        minuteSamplesTotal.inc({ outcome: "unchanged" }, unchangedAids.length);
+      }
+      if (failedAids.length > 0) {
+        minuteSamplesTotal.inc({ outcome: "failed" }, failedAids.length);
+      }
+
+      return aids.length;
+    } finally {
+      endBatch();
+    }
   }
 }

--- a/src/services/tracker.ts
+++ b/src/services/tracker.ts
@@ -3,6 +3,13 @@ import { generateBiliTicket } from "../api/signatures/biliTicket";
 import { config } from "../config";
 import type { AccountContext } from "../core/account";
 import { Database } from "../database";
+import {
+  dynamicsSeenTotal,
+  fetchCycleDurationSeconds,
+  fetchCyclesTotal,
+  lastSuccessfulFetchTimestampSeconds,
+  videosProcessedTotal,
+} from "../metrics/registry";
 import type { BiliDynamicCard, VideoData } from "../types";
 import { sleep } from "../utils/datetime";
 import { exportData } from "../utils/exporter/exporter";
@@ -38,11 +45,18 @@ export class DynamicTracker {
     this.startFollowingSyncSchedule();
 
     while (this.isRunning) {
+      const uid = this.account.uid || "unknown";
+      const endFetchCycle = fetchCycleDurationSeconds.startTimer({ uid });
       try {
         await this.checkDynamics();
+        endFetchCycle();
+        fetchCyclesTotal.inc({ uid, result: "success" });
+        lastSuccessfulFetchTimestampSeconds.set({ uid }, Date.now() / 1000);
 
         await sleep(config.application.fetchInterval);
       } catch (error) {
+        endFetchCycle();
+        fetchCyclesTotal.inc({ uid, result: "error" });
         logger.error(`[uid=${this.account.uid}] Tracker error:`, error);
         if (error instanceof Error) {
           logger.error(error.stack);
@@ -115,6 +129,10 @@ export class DynamicTracker {
       logger.info(
         `[uid=${this.account.uid}] Got new dynamic page: type=${typeCode}, ${cards.length} cards`,
       );
+      dynamicsSeenTotal.inc(
+        { uid: this.account.uid || "unknown", type: String(typeCode) },
+        cards.length,
+      );
 
       // Save all dynamics to DB immediately (decouple storage from processing)
       await Promise.all(
@@ -133,6 +151,10 @@ export class DynamicTracker {
         const processedVideos = await this.processPage(cards);
 
         if (processedVideos.length > 0) {
+          videosProcessedTotal.inc(
+            { uid: this.account.uid || "unknown" },
+            processedVideos.length,
+          );
           await exportData(processedVideos);
           await notifyNewVideos(processedVideos);
         }

--- a/src/utils/exporter/exporter.ts
+++ b/src/utils/exporter/exporter.ts
@@ -1,4 +1,5 @@
 import { config } from "../../config";
+import { exportsTotal } from "../../metrics/registry";
 import type { VideoData } from "../../types";
 import { saveToMysql } from "./mysql";
 
@@ -15,6 +16,10 @@ export async function exportData(data: VideoData[]) {
     config.export.mysql.table
   ) {
     const mysqlResult = await saveToMysql(data);
+    exportsTotal.inc({
+      target: "mysql",
+      result: mysqlResult ? "success" : "error",
+    });
     results.push({ type: "mysql", success: mysqlResult });
   }
 

--- a/src/utils/notifier/email.ts
+++ b/src/utils/notifier/email.ts
@@ -35,5 +35,6 @@ export async function sendEmailMessage(message: string) {
     if (error instanceof Error) {
       logger.error(error.stack);
     }
+    throw error;
   }
 }

--- a/src/utils/notifier/http.ts
+++ b/src/utils/notifier/http.ts
@@ -157,6 +157,7 @@ export async function sendHttpNotification(
   const delay = config.notifications.http.delay ?? 100;
 
   // Process endpoints sequentially with delay
+  const errors: Error[] = [];
   for (let i = 0; i < config.notifications.http.endpoints.length; i++) {
     const endpoint = config.notifications.http.endpoints[i];
 
@@ -167,11 +168,16 @@ export async function sendHttpNotification(
         `Failed to send HTTP notification to ${endpoint.url}:`,
         error,
       );
+      errors.push(error instanceof Error ? error : new Error(String(error)));
     }
 
     // Add delay between requests (except for the last one)
     if (i < config.notifications.http.endpoints.length - 1) {
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
+  }
+
+  if (errors.length > 0) {
+    throw errors[0];
   }
 }

--- a/src/utils/notifier/notifier.ts
+++ b/src/utils/notifier/notifier.ts
@@ -1,9 +1,29 @@
 import { config } from "../../config";
+import { notificationsTotal } from "../../metrics/registry";
 import type { VideoData } from "../../types";
 import { logger } from "../logger";
 import { sendEmailMessage } from "./email";
 import { sendHttpNotification } from "./http";
 import { sendTelegramNewVideo, sendTelegramWarning } from "./telegram";
+
+type NotificationChannel = "telegram" | "email" | "http";
+
+interface NotificationAttempt {
+  channel: NotificationChannel;
+  promise: Promise<void>;
+}
+
+function recordSettledNotifications(
+  attempts: NotificationAttempt[],
+  results: PromiseSettledResult<void>[],
+): void {
+  for (let i = 0; i < attempts.length; i++) {
+    notificationsTotal.inc({
+      channel: attempts[i].channel,
+      result: results[i].status === "fulfilled" ? "success" : "error",
+    });
+  }
+}
 
 // Template data interface for video notifications
 export interface VideoTemplateData {
@@ -25,10 +45,20 @@ export async function notifyWarning(
   message: string,
   videoData?: VideoTemplateData,
 ): Promise<void> {
-  const promises: Promise<void>[] = [];
+  const attempts: NotificationAttempt[] = [];
 
   // Telegram - Uses warning logic
-  promises.push(sendTelegramWarning(message));
+  if (
+    config.notifications.telegram.enabled &&
+    config.notifications.telegram.warningEnabled &&
+    config.notifications.telegram.botToken &&
+    config.notifications.telegram.chatId
+  ) {
+    attempts.push({
+      channel: "telegram",
+      promise: sendTelegramWarning(message),
+    });
+  }
 
   if (
     config.notifications.email.enabled &&
@@ -36,19 +66,26 @@ export async function notifyWarning(
     config.notifications.email.username &&
     config.notifications.email.to
   ) {
-    promises.push(sendEmailMessage(message));
+    attempts.push({ channel: "email", promise: sendEmailMessage(message) });
   }
 
-  if (config.notifications.http.enabled) {
-    promises.push(sendHttpNotification(message, videoData));
+  if (
+    config.notifications.http.enabled &&
+    config.notifications.http.endpoints.length > 0
+  ) {
+    attempts.push({
+      channel: "http",
+      promise: sendHttpNotification(message, videoData),
+    });
   }
 
-  if (promises.length === 0) {
+  if (attempts.length === 0) {
     logger.debug(message);
     return;
   }
 
-  await Promise.all(promises);
+  const results = await Promise.allSettled(attempts.map((a) => a.promise));
+  recordSettledNotifications(attempts, results);
 }
 
 /**
@@ -73,10 +110,20 @@ export async function notifyNewVideos(videos: VideoData[]): Promise<void> {
       tag: video.tag,
     };
 
-    const notificationPromises: Promise<void>[] = [];
+    const notificationAttempts: NotificationAttempt[] = [];
 
     // Telegram - Uses new video logic
-    notificationPromises.push(sendTelegramNewVideo(message));
+    if (
+      config.notifications.telegram.enabled &&
+      config.notifications.telegram.newVideoEnabled &&
+      config.notifications.telegram.botToken &&
+      config.notifications.telegram.chatId
+    ) {
+      notificationAttempts.push({
+        channel: "telegram",
+        promise: sendTelegramNewVideo(message),
+      });
+    }
 
     // Email
     if (
@@ -85,16 +132,28 @@ export async function notifyNewVideos(videos: VideoData[]): Promise<void> {
       config.notifications.email.username &&
       config.notifications.email.to
     ) {
-      notificationPromises.push(sendEmailMessage(message));
+      notificationAttempts.push({
+        channel: "email",
+        promise: sendEmailMessage(message),
+      });
     }
 
     // HTTP
-    if (config.notifications.http.enabled) {
-      notificationPromises.push(sendHttpNotification(message, videoData));
+    if (
+      config.notifications.http.enabled &&
+      config.notifications.http.endpoints.length > 0
+    ) {
+      notificationAttempts.push({
+        channel: "http",
+        promise: sendHttpNotification(message, videoData),
+      });
     }
 
-    if (notificationPromises.length > 0) {
-      await Promise.all(notificationPromises);
+    if (notificationAttempts.length > 0) {
+      const results = await Promise.allSettled(
+        notificationAttempts.map((a) => a.promise),
+      );
+      recordSettledNotifications(notificationAttempts, results);
     } else {
       logger.debug(message);
     }

--- a/src/utils/notifier/telegram.ts
+++ b/src/utils/notifier/telegram.ts
@@ -17,6 +17,7 @@ async function sendTelegramMessageInternal(message: string) {
     if (error instanceof Error) {
       logger.error(error.stack);
     }
+    throw error;
   }
 }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const APP_VERSION = "5.1.0";


### PR DESCRIPTION
## Summary
- add optional [metrics] config and built-in Prometheus /metrics HTTP endpoint
- instrument API, fetch loop, rate limiter, PostgreSQL, adaptive minute batches, notifications, exports, and fatal exits
- bump package/app version to 5.1.0 and document scrape/auth usage

## Verification
- pnpm check
- pnpm exec tsc --noEmit
- pnpm build
- metrics smoke: enabled endpoint with auth token, verified 401 without token and 200 with bili_tracker_build_info/api metric families