### PR TITLE
feat: add repair control API filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,24 +83,34 @@ cookie_file = "./.cookies.txt"  # Path to Netscape cookie file
 
 ### Prometheus Metrics
 
-Metrics are disabled by default. Enable the built-in Prometheus scrape endpoint
-with a `[metrics]` block or environment variables:
+Metrics are disabled by default. Enable the shared HTTP listener and the
+built-in Prometheus scrape endpoint with `[server]` and `[metrics]` blocks or
+environment variables:
 
 ```toml
-[metrics]
+[server]
 enabled = true
 host = "127.0.0.1"
 port = 9469
+# auth_token = "change-me"
+
+[metrics]
+enabled = true
 path = "/metrics"
 collect_default_metrics = true
-# auth_token = "change-me"
 ```
 
-When `auth_token` is set, scrape requests must include
-`Authorization: Bearer <token>`. The endpoint exports process metrics plus
-application metrics with the `bili_tracker_` prefix for fetch cycles, Bilibili
-API latency and errors, rate limiter depth, PostgreSQL query and pool state,
-adaptive minute sampling, notifications, exports, and fatal exit reasons.
+Equivalent environment variables are `SERVER_ENABLED`, `SERVER_HOST`,
+`SERVER_PORT`, `SERVER_AUTH_TOKEN`, `METRICS_ENABLED`, `METRICS_PATH`, and
+`METRICS_COLLECT_DEFAULT`. Older `METRICS_HOST`, `METRICS_PORT`, and
+`METRICS_AUTH_TOKEN` values are still accepted as listener fallbacks. When
+`server.auth_token` is set, scrape requests must include `Authorization: Bearer
+<token>`.
+
+The endpoint exports process metrics plus application metrics with the
+`bili_tracker_` prefix for fetch cycles, Bilibili API latency and errors, rate
+limiter depth, PostgreSQL query and pool state, adaptive minute sampling,
+notifications, exports, and fatal exit reasons.
 
 Prometheus scrape example:
 
@@ -122,6 +132,74 @@ Metric interpretation notes:
   treated as normal business outcomes, not API transport errors.
 - When a proxy is configured, a failed proxied API request followed by a direct
   fallback is counted as two API request samples with different `host` labels.
+
+### Repair API
+
+The shared HTTP listener can also expose repair control endpoints when
+`repair.api_enabled = true` or `REPAIR_API_ENABLED=true`. Repair requests
+rewrite stored video data and call Bilibili APIs, so they require
+`server.auth_token`; if no token is configured, the repair API returns `403`.
+
+```toml
+[repair]
+api_enabled = true
+path = "/repair"
+status_path = "/repair/status"
+max_bvids = 1000
+```
+
+Start a repair job for specific videos:
+
+```bash
+curl -X POST http://127.0.0.1:9469/repair \
+  -H "Authorization: Bearer $SERVER_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"bvids":["BV1xx411c7mD"]}'
+```
+
+Supported JSON fields are:
+
+- `bvid`: one BV id to repair.
+- `bvids`: up to 1000 BV ids to repair.
+- `all`: repair every stored video when set to `true`.
+- `filter`: structured selection over stored `processed_videos`.
+- `fixAids`: repair aid/bvid mismatches before processing videos.
+
+Filter example:
+
+```bash
+curl -X POST http://127.0.0.1:9469/repair \
+  -H "Authorization: Bearer $SERVER_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"filter":{"columns":{"user_id":{"in":["123456"]},"type_id":{"in":[28,30]},"is_filtered":true,"is_deleted":false,"dynamic":{"isNull":false},"updated_at":{"gte":"2026-06-01T00:00:00Z"}},"limit":100}}'
+```
+
+`filter.columns` supports all `processed_videos` columns: `aid`, `bvid`,
+`pubdate`, `title`, `description`, `tag`, `pic`, `type_id`, `user_id`,
+`is_filtered`, `created_at`, `updated_at`, `staff`, `tid_v2`, `dynamic`,
+`tag_new`, `participle`, `ctime`, `is_deleted`, `copyright`, `extras`, and
+`notes`.
+
+Column filters accept direct equality values or operation objects. Supported
+operations are:
+
+- `isNull`: `true` becomes `IS NULL`; `false` becomes `IS NOT NULL`.
+- `eq` and `in`: exact match for scalar columns.
+- `min`, `max`, `gt`, `gte`, `lt`, `lte`: number and timestamp comparisons.
+- `contains`: `ILIKE` for text columns, `@>` for JSONB, overlap for arrays.
+- `hasAny`, `hasAll`, `isEmpty`: array columns.
+
+Legacy aliases remain accepted for convenience: `bvids`, `userIds`, `typeIds`,
+`isFiltered`, `isDeleted`, `createdAfter`, `createdBefore`, `updatedAfter`,
+`updatedBefore`, `pubdateAfter`, and `pubdateBefore`. The API builds
+parameterized SQL from those fields; raw SQL filters remain CLI-only.
+
+Only one repair job can run at a time. Check the current or most recent job:
+
+```bash
+curl http://127.0.0.1:9469/repair/status \
+  -H "Authorization: Bearer $SERVER_AUTH_TOKEN"
+```
 
 ## Development
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -45,14 +45,25 @@ retrospective_days = 30        # Days to look back during retrospective scan (de
 url = "postgresql://localhost:5432/hantang"  # PostgreSQL connection URL
 schema = "public"                            # PostgreSQL schema name (default: public)
 
-[metrics]
-# Prometheus metrics endpoint (disabled by default)
+[server]
+# Shared HTTP listener for metrics and control APIs (disabled by default)
 enabled = false
 host = "127.0.0.1"                 # Use "0.0.0.0" when scraping from outside the container/host
 port = 9469
+# auth_token = "change-me"         # Requires Authorization: Bearer <token> for protected APIs
+
+[metrics]
+# Prometheus metrics endpoint
+enabled = false
 path = "/metrics"
 collect_default_metrics = true
-# auth_token = "change-me"         # Requires Authorization: Bearer <token>
+
+[repair]
+# Repair control API on the shared server listener
+api_enabled = false
+path = "/repair"
+status_path = "/repair/status"
+max_bvids = 1000
 
 [minute]
 # Adaptive minute collection with progressive gate-approach acceleration.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -13,12 +13,16 @@ import {
   createMinuteConfig,
   createNotificationsConfig,
   createProcessingConfig,
+  createRepairConfig,
+  createServerConfig,
   databaseSchema,
   exportSchema,
   metricsSchema,
   minuteSchema,
   notificationsSchema,
   processingSchema,
+  repairSchema,
+  serverSchema,
 } from "./schemas";
 
 let tomlData: unknown = {};
@@ -80,6 +84,8 @@ const configSchema = z.object({
   processing: processingSchema,
   export: exportSchema,
   metrics: metricsSchema,
+  repair: repairSchema,
+  server: serverSchema,
   notifications: notificationsSchema,
 });
 
@@ -91,5 +97,7 @@ export const config = configSchema.parse({
   processing: createProcessingConfig(getConfigValue),
   export: createExportConfig(getConfigValue),
   metrics: createMetricsConfig(getConfigValue),
+  repair: createRepairConfig(getConfigValue),
+  server: createServerConfig(getConfigValue),
   notifications: createNotificationsConfig(getConfigValue),
 });

--- a/src/config/schemas/index.ts
+++ b/src/config/schemas/index.ts
@@ -9,3 +9,5 @@ export {
   notificationsSchema,
 } from "./notifications";
 export { createProcessingConfig, processingSchema } from "./processing";
+export { createRepairConfig, repairSchema } from "./repair";
+export { createServerConfig, serverSchema } from "./server";

--- a/src/config/schemas/metrics.ts
+++ b/src/config/schemas/metrics.ts
@@ -7,11 +7,8 @@ const configBoolean = z.preprocess((value) => {
 
 export const metricsSchema = z.object({
   enabled: configBoolean.default(false),
-  host: z.string().default("127.0.0.1"),
-  port: z.coerce.number().int().positive().default(9469),
   path: z.string().startsWith("/").default("/metrics"),
   collectDefaultMetrics: configBoolean.default(true),
-  authToken: z.string().optional(),
 });
 
 export type MetricsConfig = z.infer<typeof metricsSchema>;
@@ -27,18 +24,11 @@ export function createMetricsConfig(
 ): MetricsConfig {
   return metricsSchema.parse({
     enabled: getConfigValue(["metrics", "enabled"], "METRICS_ENABLED", false),
-    host: getConfigValue(["metrics", "host"], "METRICS_HOST", "127.0.0.1"),
-    port: getConfigValue(["metrics", "port"], "METRICS_PORT", 9469),
     path: getConfigValue(["metrics", "path"], "METRICS_PATH", "/metrics"),
     collectDefaultMetrics: getConfigValue(
       ["metrics", "collect_default_metrics"],
       "METRICS_COLLECT_DEFAULT",
       true,
-    ),
-    authToken: getConfigValue(
-      ["metrics", "auth_token"],
-      "METRICS_AUTH_TOKEN",
-      undefined,
     ),
   });
 }

--- a/src/config/schemas/repair.ts
+++ b/src/config/schemas/repair.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+const configBoolean = z.preprocess((value) => {
+  if (typeof value !== "string") return value;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}, z.boolean());
+
+export const repairSchema = z.object({
+  apiEnabled: configBoolean.default(false),
+  path: z.string().startsWith("/").default("/repair"),
+  statusPath: z.string().startsWith("/").default("/repair/status"),
+  maxBvids: z.coerce.number().int().positive().max(10_000).default(1000),
+});
+
+export type RepairConfig = z.infer<typeof repairSchema>;
+
+export function createRepairConfig(
+  getConfigValue: (
+    tomlPath: string[],
+    envKey: string,
+    // biome-ignore lint/suspicious/noExplicitAny: Config values from TOML/env are inherently untyped and validated by zod
+    defaultValue?: any,
+    // biome-ignore lint/suspicious/noExplicitAny: Config values from TOML/env are inherently untyped and validated by zod
+  ) => any,
+): RepairConfig {
+  return repairSchema.parse({
+    apiEnabled: getConfigValue(
+      ["repair", "api_enabled"],
+      "REPAIR_API_ENABLED",
+      false,
+    ),
+    path: getConfigValue(["repair", "path"], "REPAIR_PATH", "/repair"),
+    statusPath: getConfigValue(
+      ["repair", "status_path"],
+      "REPAIR_STATUS_PATH",
+      "/repair/status",
+    ),
+    maxBvids: getConfigValue(["repair", "max_bvids"], "REPAIR_MAX_BVIDS", 1000),
+  });
+}

--- a/src/config/schemas/server.ts
+++ b/src/config/schemas/server.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+const configBoolean = z.preprocess((value) => {
+  if (typeof value !== "string") return value;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}, z.boolean());
+
+export const serverSchema = z.object({
+  enabled: configBoolean.default(false),
+  host: z.string().default("127.0.0.1"),
+  port: z.coerce.number().int().positive().default(9469),
+  authToken: z.string().optional(),
+});
+
+export type ServerConfig = z.infer<typeof serverSchema>;
+
+export function createServerConfig(
+  getConfigValue: (
+    tomlPath: string[],
+    envKey: string,
+    // biome-ignore lint/suspicious/noExplicitAny: Config values from TOML/env are inherently untyped and validated by zod
+    defaultValue?: any,
+    // biome-ignore lint/suspicious/noExplicitAny: Config values from TOML/env are inherently untyped and validated by zod
+  ) => any,
+): ServerConfig {
+  return serverSchema.parse({
+    enabled: getConfigValue(
+      ["server", "enabled"],
+      "SERVER_ENABLED",
+      getConfigValue(["metrics", "enabled"], "METRICS_ENABLED", false),
+    ),
+    host: getConfigValue(
+      ["server", "host"],
+      "SERVER_HOST",
+      getConfigValue(["metrics", "host"], "METRICS_HOST", "127.0.0.1"),
+    ),
+    port: getConfigValue(
+      ["server", "port"],
+      "SERVER_PORT",
+      getConfigValue(["metrics", "port"], "METRICS_PORT", 9469),
+    ),
+    authToken: getConfigValue(
+      ["server", "auth_token"],
+      "SERVER_AUTH_TOKEN",
+      getConfigValue(
+        ["metrics", "auth_token"],
+        "METRICS_AUTH_TOKEN",
+        undefined,
+      ),
+    ),
+  });
+}

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -23,6 +23,8 @@ import type {
 import type { VideoData } from "../types/models/video.js";
 import { logger } from "../utils/logger.js";
 
+export type { BvidListQuery } from "./videos.js";
+
 function quotePostgresIdentifier(identifier: string): string {
   return `"${identifier.replace(/"/g, '""')}"`;
 }
@@ -84,6 +86,7 @@ import {
 import { getDailyCollectionCandidates } from "./videoDaily.js";
 import { insertVideoMinuteSamples } from "./videoMinute.js";
 import {
+  type BvidListQuery,
   getAllProcessedIds,
   getBvidList,
   getProcessedVideos,
@@ -282,8 +285,8 @@ export class Database {
   /**
    * Get list of bvids only (lightweight, for batch processing)
    */
-  public async getBvidList(where?: string): Promise<string[]> {
-    return getBvidList(this.ensurePool(), where);
+  public async getBvidList(query?: string | BvidListQuery): Promise<string[]> {
+    return getBvidList(this.ensurePool(), query);
   }
 
   /**

--- a/src/database/schema/collection_queue.ts
+++ b/src/database/schema/collection_queue.ts
@@ -13,12 +13,24 @@ export async function initCollectionQueueSchema(pool: Pool): Promise<void> {
   await pool.query(`DROP TABLE IF EXISTS video_collection_queue CASCADE`);
 
   // ── Drop legacy queue-only functions ─────────────────────────────
-  await pool.query(`DROP FUNCTION IF EXISTS fn_advance_abandoned_minute_collection_state(timestamptz)`);
-  await pool.query(`DROP FUNCTION IF EXISTS fn_enqueue_video_collection_tasks(timestamptz, integer)`);
-  await pool.query(`DROP FUNCTION IF EXISTS fn_enqueue_video_collection_gate_tasks(timestamptz, interval, numeric, bigint, integer, text)`);
-  await pool.query(`DROP FUNCTION IF EXISTS fn_claim_video_collection_tasks(timestamptz, integer, interval)`);
-  await pool.query(`DROP FUNCTION IF EXISTS fn_ack_video_collection_tasks(bigint[], timestamptz)`);
-  await pool.query(`DROP FUNCTION IF EXISTS fn_fail_video_collection_tasks(bigint[], timestamptz)`);
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_advance_abandoned_minute_collection_state(timestamptz)`,
+  );
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_enqueue_video_collection_tasks(timestamptz, integer)`,
+  );
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_enqueue_video_collection_gate_tasks(timestamptz, interval, numeric, bigint, integer, text)`,
+  );
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_claim_video_collection_tasks(timestamptz, integer, interval)`,
+  );
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_ack_video_collection_tasks(bigint[], timestamptz)`,
+  );
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_fail_video_collection_tasks(bigint[], timestamptz)`,
+  );
 
   // ── Gate crossing records (still used by triggers) ───────────────
   await pool.query(`

--- a/src/database/videos.ts
+++ b/src/database/videos.ts
@@ -2,6 +2,12 @@ import type { Pool } from "pg";
 import type { VideoSnapshot } from "../types/models/database.js";
 import type { VideoData } from "../types/models/video.js";
 
+export interface BvidListQuery {
+  where?: string;
+  params?: unknown[];
+  limit?: number;
+}
+
 /**
  * Check if a video has been processed
  */
@@ -191,15 +197,24 @@ export async function markVideoDeleted(
  */
 export async function getBvidList(
   pool: Pool,
-  where?: string,
+  query: string | BvidListQuery = {},
 ): Promise<string[]> {
+  const normalizedQuery = typeof query === "string" ? { where: query } : query;
   let sql = "SELECT bvid FROM processed_videos";
-  if (where) {
-    sql += ` WHERE ${where}`;
+  if (normalizedQuery.where) {
+    sql += ` WHERE ${normalizedQuery.where}`;
   }
   sql += " ORDER BY created_at DESC";
+  if (normalizedQuery.limit !== undefined) {
+    sql += ` LIMIT $${(normalizedQuery.params ?? []).length + 1}`;
+  }
 
-  const result = await pool.query(sql);
+  const params =
+    normalizedQuery.limit !== undefined
+      ? [...(normalizedQuery.params ?? []), normalizedQuery.limit]
+      : (normalizedQuery.params ?? []);
+
+  const result = await pool.query(sql, params);
   return result.rows.map((row) => row.bvid as string);
 }
 

--- a/src/metrics/server.ts
+++ b/src/metrics/server.ts
@@ -1,13 +1,101 @@
-import { timingSafeEqual } from "node:crypto";
-import { createServer, type Server } from "node:http";
+import { randomUUID, timingSafeEqual } from "node:crypto";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
 import { config } from "../config";
+import { Database } from "../database";
+import {
+  type RepairColumnFilterOperators,
+  type RepairColumnFilterValue,
+  type RepairResult,
+  type RepairVideoFilter,
+  runRepairVideosWithDatabase,
+} from "../scripts/repair-videos";
 import { logger } from "../utils/logger";
 import { metricsRegistry } from "./registry";
 
+const MAX_JSON_BODY_BYTES = 64 * 1024;
+const BVID_PATTERN = /^BV[0-9A-Za-z]{10}$/;
+const REPAIR_FILTER_COLUMNS = new Set([
+  "aid",
+  "bvid",
+  "copyright",
+  "created_at",
+  "ctime",
+  "description",
+  "dynamic",
+  "extras",
+  "is_deleted",
+  "is_filtered",
+  "notes",
+  "participle",
+  "pic",
+  "pubdate",
+  "staff",
+  "tag",
+  "tag_new",
+  "tid_v2",
+  "title",
+  "type_id",
+  "updated_at",
+  "user_id",
+]);
+
+type RepairFilterColumnName =
+  | "aid"
+  | "bvid"
+  | "copyright"
+  | "created_at"
+  | "ctime"
+  | "description"
+  | "dynamic"
+  | "extras"
+  | "is_deleted"
+  | "is_filtered"
+  | "notes"
+  | "participle"
+  | "pic"
+  | "pubdate"
+  | "staff"
+  | "tag"
+  | "tag_new"
+  | "tid_v2"
+  | "title"
+  | "type_id"
+  | "updated_at"
+  | "user_id";
+
 let server: Server | null = null;
 
+interface NormalizedRepairRequest {
+  all: boolean;
+  bvids?: string[];
+  filter?: RepairVideoFilter;
+  fixAids: boolean;
+}
+
+interface RepairJobView {
+  id: string;
+  status: "running" | "succeeded" | "failed";
+  startedAt: string;
+  finishedAt?: string;
+  request: {
+    all: boolean;
+    bvidCount: number;
+    filter?: RepairVideoFilter;
+    fixAids: boolean;
+  };
+  result?: RepairResult;
+  error?: string;
+}
+
+let repairJob: RepairJobView | null = null;
+
 function isAuthorized(authorization: string | undefined): boolean {
-  const expected = `Bearer ${config.metrics.authToken}`;
+  const expected = `Bearer ${config.server.authToken}`;
   if (!authorization) {
     return false;
   }
@@ -19,6 +107,503 @@ function isAuthorized(authorization: string | undefined): boolean {
   }
 
   return timingSafeEqual(authorizationBuffer, expectedBuffer);
+}
+
+function sendJson(
+  res: ServerResponse,
+  statusCode: number,
+  payload: unknown,
+): void {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json");
+  res.end(`${JSON.stringify(payload)}\n`);
+}
+
+function sendText(
+  res: ServerResponse,
+  statusCode: number,
+  payload: string,
+): void {
+  res.statusCode = statusCode;
+  res.end(payload);
+}
+
+function ensureMetricsAuthorization(
+  req: IncomingMessage,
+  res: ServerResponse,
+): boolean {
+  if (!config.server.authToken) return true;
+
+  if (!isAuthorized(req.headers.authorization)) {
+    sendText(res, 401, "Unauthorized\n");
+    return false;
+  }
+
+  return true;
+}
+
+function ensureRepairAuthorization(
+  req: IncomingMessage,
+  res: ServerResponse,
+): boolean {
+  if (!config.repair.apiEnabled) {
+    sendJson(res, 404, { error: "Not Found" });
+    return false;
+  }
+
+  if (!config.server.authToken) {
+    sendJson(res, 403, {
+      error: "Repair API requires server.auth_token",
+    });
+    return false;
+  }
+
+  if (!isAuthorized(req.headers.authorization)) {
+    sendJson(res, 401, { error: "Unauthorized" });
+    return false;
+  }
+
+  return true;
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.length;
+
+    if (totalBytes > MAX_JSON_BODY_BYTES) {
+      throw new Error("Request body too large");
+    }
+
+    chunks.push(buffer);
+  }
+
+  const body = Buffer.concat(chunks).toString("utf8").trim();
+  if (!body) return {};
+
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    throw new Error("Request body must be valid JSON");
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readBooleanField(body: Record<string, unknown>, key: string): boolean {
+  const value = body[key];
+  if (value === undefined) return false;
+  if (typeof value !== "boolean") {
+    throw new Error(`${key} must be a boolean`);
+  }
+
+  return value;
+}
+
+function readBvid(value: unknown, fieldName: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${fieldName} must be a string`);
+  }
+
+  const bvid = value.trim();
+  if (!BVID_PATTERN.test(bvid)) {
+    throw new Error(`${fieldName} must be a BV id`);
+  }
+
+  return bvid;
+}
+
+function readIntegerField(
+  body: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = body[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`${key} must be an integer`);
+  }
+
+  return value;
+}
+
+function readBvidArrayField(
+  body: Record<string, unknown>,
+  key: string,
+): string[] | undefined {
+  const value = body[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error(`${key} must be an array`);
+  }
+
+  if (value.length > config.repair.maxBvids) {
+    throw new Error(
+      `${key} cannot contain more than ${config.repair.maxBvids} ids`,
+    );
+  }
+
+  return value.map((item, index) => readBvid(item, `${key}[${index}]`));
+}
+
+function readArrayField(body: Record<string, unknown>, key: string): unknown[] {
+  const value = body[key];
+  if (!Array.isArray(value)) {
+    throw new Error(`${key} must be an array`);
+  }
+  return value;
+}
+
+function isRepairColumn(column: string): column is RepairFilterColumnName {
+  return REPAIR_FILTER_COLUMNS.has(column);
+}
+
+function readColumnFilterValue(
+  value: unknown,
+  fieldName: string,
+): RepairColumnFilterValue {
+  if (
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string" ||
+    Array.isArray(value)
+  ) {
+    return value;
+  }
+
+  if (!isRecord(value)) {
+    throw new Error(`${fieldName} must be a scalar, array, or object`);
+  }
+
+  const normalized: RepairColumnFilterOperators = {};
+  const allowedOperators = new Set([
+    "contains",
+    "eq",
+    "gt",
+    "gte",
+    "hasAll",
+    "hasAny",
+    "in",
+    "isEmpty",
+    "isNull",
+    "lt",
+    "lte",
+    "max",
+    "min",
+  ]);
+
+  for (const [operator, operatorValue] of Object.entries(value)) {
+    if (!allowedOperators.has(operator)) {
+      throw new Error(`${fieldName}.${operator} is not supported`);
+    }
+
+    if (
+      (operator === "hasAll" || operator === "hasAny" || operator === "in") &&
+      !Array.isArray(operatorValue)
+    ) {
+      throw new Error(`${fieldName}.${operator} must be an array`);
+    }
+
+    if (
+      (operator === "isEmpty" || operator === "isNull") &&
+      typeof operatorValue !== "boolean"
+    ) {
+      throw new Error(`${fieldName}.${operator} must be a boolean`);
+    }
+
+    switch (operator) {
+      case "hasAll":
+      case "hasAny":
+      case "in":
+        if (!Array.isArray(operatorValue)) {
+          throw new Error(`${fieldName}.${operator} must be an array`);
+        }
+        normalized[operator] = operatorValue;
+        break;
+      case "isEmpty":
+      case "isNull":
+        if (typeof operatorValue !== "boolean") {
+          throw new Error(`${fieldName}.${operator} must be a boolean`);
+        }
+        normalized[operator] = operatorValue;
+        break;
+      case "contains":
+        normalized.contains = operatorValue;
+        break;
+      case "eq":
+        normalized.eq = operatorValue;
+        break;
+      case "gt":
+        normalized.gt = operatorValue;
+        break;
+      case "gte":
+        normalized.gte = operatorValue;
+        break;
+      case "lt":
+        normalized.lt = operatorValue;
+        break;
+      case "lte":
+        normalized.lte = operatorValue;
+        break;
+      case "max":
+        normalized.max = operatorValue;
+        break;
+      case "min":
+        normalized.min = operatorValue;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeRepairFilter(value: unknown): RepairVideoFilter | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    throw new Error("filter must be a JSON object");
+  }
+
+  const limit = readIntegerField(value, "limit");
+  const columns: Partial<
+    Record<RepairFilterColumnName, RepairColumnFilterValue>
+  > = {};
+
+  if (value.columns !== undefined) {
+    if (!isRecord(value.columns)) {
+      throw new Error("filter.columns must be a JSON object");
+    }
+
+    for (const [column, columnValue] of Object.entries(value.columns)) {
+      if (!isRepairColumn(column)) {
+        throw new Error(`filter.columns.${column} is not supported`);
+      }
+
+      columns[column] = readColumnFilterValue(
+        columnValue,
+        `filter.columns.${column}`,
+      );
+    }
+  }
+
+  for (const [column, columnValue] of Object.entries(value)) {
+    if (column === "columns" || column === "limit") continue;
+    if (!isRepairColumn(column)) continue;
+    columns[column] = readColumnFilterValue(columnValue, `filter.${column}`);
+  }
+
+  if (value.bvids !== undefined) {
+    columns.bvid = {
+      in: [...new Set(readBvidArrayField(value, "bvids") ?? [])],
+    };
+  }
+  if (value.userIds !== undefined) {
+    columns.user_id = { in: readArrayField(value, "userIds") };
+  }
+  if (value.typeIds !== undefined) {
+    columns.type_id = { in: readArrayField(value, "typeIds") };
+  }
+  if (value.isFiltered !== undefined) {
+    columns.is_filtered = readBooleanField(value, "isFiltered");
+  }
+  if (value.isDeleted !== undefined) {
+    columns.is_deleted = readBooleanField(value, "isDeleted");
+  }
+  if (value.createdAfter !== undefined) {
+    columns.created_at = { gte: value.createdAfter };
+  }
+  if (value.createdBefore !== undefined) {
+    columns.created_at = {
+      ...(isRecord(columns.created_at) ? columns.created_at : {}),
+      lte: value.createdBefore,
+    };
+  }
+  if (value.updatedAfter !== undefined) {
+    columns.updated_at = { gte: value.updatedAfter };
+  }
+  if (value.updatedBefore !== undefined) {
+    columns.updated_at = {
+      ...(isRecord(columns.updated_at) ? columns.updated_at : {}),
+      lte: value.updatedBefore,
+    };
+  }
+  if (value.pubdateAfter !== undefined) {
+    columns.pubdate = { gte: value.pubdateAfter };
+  }
+  if (value.pubdateBefore !== undefined) {
+    columns.pubdate = {
+      ...(isRecord(columns.pubdate) ? columns.pubdate : {}),
+      lte: value.pubdateBefore,
+    };
+  }
+
+  const filter: RepairVideoFilter = {};
+  if (Object.keys(columns).length > 0) {
+    filter.columns = columns;
+  }
+
+  if (limit !== undefined) {
+    if (limit < 1) {
+      throw new Error("filter.limit must be a positive integer");
+    }
+    filter.limit = limit;
+  }
+
+  return filter.columns || filter.limit !== undefined ? filter : undefined;
+}
+
+function normalizeRepairRequest(body: unknown): NormalizedRepairRequest {
+  if (!isRecord(body)) {
+    throw new Error("Request body must be a JSON object");
+  }
+
+  const all = readBooleanField(body, "all");
+  const fixAids = readBooleanField(body, "fixAids");
+  const filter = normalizeRepairFilter(body.filter);
+  const bvids: string[] = [];
+
+  if (body.bvid !== undefined) {
+    bvids.push(readBvid(body.bvid, "bvid"));
+  }
+
+  if (body.bvids !== undefined) {
+    bvids.push(...(readBvidArrayField(body, "bvids") ?? []));
+  }
+
+  const uniqueBvids = [...new Set(bvids)];
+
+  if (all && uniqueBvids.length > 0) {
+    throw new Error("all cannot be combined with bvid or bvids");
+  }
+
+  if (all && filter) {
+    throw new Error("all cannot be combined with filter");
+  }
+
+  if (uniqueBvids.length > 0 && filter) {
+    throw new Error("bvid or bvids cannot be combined with filter");
+  }
+
+  if (!all && uniqueBvids.length === 0 && !filter && !fixAids) {
+    throw new Error("Specify all=true, bvid, bvids, filter, or fixAids=true");
+  }
+
+  return {
+    all,
+    bvids: uniqueBvids.length > 0 ? uniqueBvids : undefined,
+    filter,
+    fixAids,
+  };
+}
+
+async function handleMetricsRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if (req.method !== "GET") {
+    sendText(res, 405, "Method Not Allowed\n");
+    return;
+  }
+
+  if (!ensureMetricsAuthorization(req, res)) return;
+
+  try {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", metricsRegistry.contentType);
+    res.end(await metricsRegistry.metrics());
+  } catch (error) {
+    logger.error("Failed to render Prometheus metrics:", error);
+    sendText(res, 500, "Internal Server Error\n");
+  }
+}
+
+function runRepairJob(
+  job: RepairJobView,
+  request: NormalizedRepairRequest,
+): void {
+  void (async () => {
+    try {
+      const db = Database.getInstance();
+      job.result = await runRepairVideosWithDatabase(db, undefined, {
+        bvids:
+          request.all || request.filter ? undefined : (request.bvids ?? []),
+        filter: request.filter,
+        fixAids: request.fixAids,
+      });
+      job.status = "succeeded";
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : JSON.stringify(error);
+      job.error = message || "Unknown repair error";
+      job.status = "failed";
+      logger.error("Repair API job failed:", error);
+    } finally {
+      job.finishedAt = new Date().toISOString();
+    }
+  })();
+}
+
+async function handleRepairRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const path = req.url?.split("?", 1)[0] ?? "/";
+
+  if (!ensureRepairAuthorization(req, res)) return;
+
+  if (path === config.repair.statusPath) {
+    if (req.method !== "GET") {
+      sendJson(res, 405, { error: "Method Not Allowed" });
+      return;
+    }
+
+    sendJson(res, 200, repairJob ?? { status: "idle" });
+    return;
+  }
+
+  if (req.method !== "POST") {
+    sendJson(res, 405, { error: "Method Not Allowed" });
+    return;
+  }
+
+  if (repairJob?.status === "running") {
+    sendJson(res, 409, {
+      error: "A repair job is already running",
+      job: repairJob,
+    });
+    return;
+  }
+
+  let repairRequest: NormalizedRepairRequest;
+  try {
+    repairRequest = normalizeRepairRequest(await readJsonBody(req));
+  } catch (error) {
+    sendJson(res, 400, {
+      error: error instanceof Error ? error.message : "Invalid request",
+    });
+    return;
+  }
+
+  const now = new Date().toISOString();
+  repairJob = {
+    id: randomUUID(),
+    request: {
+      all: repairRequest.all,
+      bvidCount: repairRequest.all ? 0 : (repairRequest.bvids?.length ?? 0),
+      filter: repairRequest.filter,
+      fixAids: repairRequest.fixAids,
+    },
+    startedAt: now,
+    status: "running",
+  };
+
+  runRepairJob(repairJob, repairRequest);
+  sendJson(res, 202, repairJob);
 }
 
 async function closeAfterFailedListen(
@@ -38,39 +623,22 @@ async function closeAfterFailedListen(
 }
 
 export async function startMetricsServer(): Promise<void> {
-  if (!config.metrics.enabled || server) return;
+  if (!config.server.enabled || server) return;
 
   server = createServer(async (req, res) => {
-    if (req.method !== "GET") {
-      res.statusCode = 405;
-      res.end("Method Not Allowed\n");
-      return;
-    }
-
     const path = req.url?.split("?", 1)[0] ?? "/";
-    if (path !== config.metrics.path) {
-      res.statusCode = 404;
-      res.end("Not Found\n");
+
+    if (path === config.metrics.path) {
+      await handleMetricsRequest(req, res);
       return;
     }
 
-    if (config.metrics.authToken) {
-      if (!isAuthorized(req.headers.authorization)) {
-        res.statusCode = 401;
-        res.end("Unauthorized\n");
-        return;
-      }
+    if (path === config.repair.path || path === config.repair.statusPath) {
+      await handleRepairRequest(req, res);
+      return;
     }
 
-    try {
-      res.statusCode = 200;
-      res.setHeader("Content-Type", metricsRegistry.contentType);
-      res.end(await metricsRegistry.metrics());
-    } catch (error) {
-      logger.error("Failed to render Prometheus metrics:", error);
-      res.statusCode = 500;
-      res.end("Internal Server Error\n");
-    }
+    sendText(res, 404, "Not Found\n");
   });
 
   try {
@@ -78,7 +646,7 @@ export async function startMetricsServer(): Promise<void> {
       const activeServer = server;
       if (!activeServer) return reject(new Error("Metrics server missing"));
       activeServer.once("error", reject);
-      activeServer.listen(config.metrics.port, config.metrics.host, () => {
+      activeServer.listen(config.server.port, config.server.host, () => {
         activeServer.off("error", reject);
         activeServer.unref();
         resolve();
@@ -92,7 +660,7 @@ export async function startMetricsServer(): Promise<void> {
   }
 
   logger.info(
-    `Prometheus metrics listening on http://${config.metrics.host}:${config.metrics.port}${config.metrics.path}`,
+    `HTTP control server listening on http://${config.server.host}:${config.server.port}`,
   );
 }
 

--- a/src/metrics/server.ts
+++ b/src/metrics/server.ts
@@ -240,6 +240,9 @@ function readBvidArrayField(
   if (!Array.isArray(value)) {
     throw new Error(`${key} must be an array`);
   }
+  if (value.length === 0) {
+    throw new Error(`${key} cannot be empty`);
+  }
 
   if (value.length > config.repair.maxBvids) {
     throw new Error(
@@ -254,6 +257,9 @@ function readArrayField(body: Record<string, unknown>, key: string): unknown[] {
   const value = body[key];
   if (!Array.isArray(value)) {
     throw new Error(`${key} must be an array`);
+  }
+  if (value.length === 0) {
+    throw new Error(`${key} cannot be empty`);
   }
   return value;
 }
@@ -321,6 +327,9 @@ function readColumnFilterValue(
       case "in":
         if (!Array.isArray(operatorValue)) {
           throw new Error(`${fieldName}.${operator} must be an array`);
+        }
+        if (operatorValue.length === 0) {
+          throw new Error(`${fieldName}.${operator} cannot be empty`);
         }
         normalized[operator] = operatorValue;
         break;

--- a/src/scripts/repair-videos.ts
+++ b/src/scripts/repair-videos.ts
@@ -384,7 +384,8 @@ function buildRepairBvidListQuery(filter: RepairVideoFilter): BvidListQuery {
     }
 
     if (definition.kind === "array") {
-      return buildArrayClause(columnSql, [value], definition, "&&");
+      const arrayValues = Array.isArray(value) ? value : [value];
+      return buildArrayClause(columnSql, arrayValues, definition, "&&");
     }
 
     throw new Error(`${definition.apiName}.contains is not supported`);

--- a/src/scripts/repair-videos.ts
+++ b/src/scripts/repair-videos.ts
@@ -1,9 +1,76 @@
 import { config } from "../config/index.js";
-import { Database } from "../database/index.js";
+import { type BvidListQuery, Database } from "../database/index.js";
 import { DetailsService } from "../services/details.service.js";
 import { logger } from "../utils/logger.js";
 
 const POOL_SIZE = config.application.concurrencyLimit || 20;
+
+type RepairFilterColumn =
+  | "aid"
+  | "bvid"
+  | "copyright"
+  | "created_at"
+  | "ctime"
+  | "description"
+  | "dynamic"
+  | "extras"
+  | "is_deleted"
+  | "is_filtered"
+  | "notes"
+  | "participle"
+  | "pic"
+  | "pubdate"
+  | "staff"
+  | "tag"
+  | "tag_new"
+  | "tid_v2"
+  | "title"
+  | "type_id"
+  | "updated_at"
+  | "user_id";
+
+export interface RepairColumnFilterOperators {
+  contains?: unknown;
+  eq?: unknown;
+  gt?: unknown;
+  gte?: unknown;
+  hasAll?: unknown[];
+  hasAny?: unknown[];
+  in?: unknown[];
+  isEmpty?: boolean;
+  isNull?: boolean;
+  lt?: unknown;
+  lte?: unknown;
+  max?: unknown;
+  min?: unknown;
+}
+
+export type RepairColumnFilterValue =
+  | boolean
+  | number
+  | RepairColumnFilterOperators
+  | string
+  | unknown[];
+
+export interface RepairVideoFilter
+  extends Partial<Record<RepairFilterColumn, RepairColumnFilterValue>> {
+  columns?: Partial<Record<RepairFilterColumn, RepairColumnFilterValue>>;
+  limit?: number;
+}
+
+interface RepairOptions {
+  fixAids?: boolean;
+  bvids?: string[];
+  filter?: RepairVideoFilter;
+}
+
+export interface RepairResult {
+  total: number;
+  success: number;
+  skipped: number;
+  errors: number;
+  aidMismatchesFixed: number;
+}
 
 async function processVideo(
   detailsService: DetailsService,
@@ -68,54 +135,332 @@ async function runWithPool<T, R>(
 
 export async function runRepairVideos(
   filter?: string,
-  options: { fixAids?: boolean } = {},
-) {
+  options: RepairOptions = {},
+): Promise<RepairResult> {
+  const db = Database.getInstance();
+  await db.init(config.database.url);
+
+  try {
+    return await runRepairVideosWithDatabase(db, filter, options);
+  } finally {
+    await db.close();
+  }
+}
+
+export async function runRepairVideosWithDatabase(
+  db: Database,
+  filter?: string,
+  options: RepairOptions = {},
+): Promise<RepairResult> {
   logger.info("Starting video data repair script");
   if (filter) {
     logger.info(`Filter applied: ${filter}`);
   }
   logger.info(`Pool size: ${POOL_SIZE}`);
 
-  const db = Database.getInstance();
-  await db.init(config.database.url);
-
   const detailsService = new DetailsService();
+  let aidMismatchesFixed = 0;
 
-  try {
-    if (options.fixAids) {
-      logger.info("=== Repairing aid mismatches ===");
-      await repairAids(db);
-    }
-    // Use lightweight getBvidList instead of loading full VideoData objects
-    const allBvids = await db.getBvidList(filter);
-    // Deduplicate by bvid to avoid concurrent processing of same video
-    const bvids = [...new Set(allBvids)];
-    logger.info(
-      `Found ${allBvids.length} videos, ${bvids.length} unique bvids to repair`,
-    );
-
-    let successCount = 0;
-    let errorCount = 0;
-    let skippedCount = 0;
-
-    const results = await runWithPool(bvids, POOL_SIZE, async (bvid, index) => {
-      return processVideo(detailsService, bvid, index + 1, bvids.length);
-    });
-
-    for (const result of results) {
-      if (result.success) successCount++;
-      else if (result.skipped) skippedCount++;
-      else errorCount++;
-    }
-
-    logger.info("\n=== Repair Complete ===");
-    logger.info(`Total: ${bvids.length}`);
-    logger.info(`Success: ${successCount}`);
-    logger.info(`Skipped: ${skippedCount}`);
-    logger.info(`Errors: ${errorCount}`);
-  } finally {
-    await db.close();
+  if (options.fixAids) {
+    logger.info("=== Repairing aid mismatches ===");
+    aidMismatchesFixed = await repairAids(db);
   }
+
+  // Use lightweight getBvidList instead of loading full VideoData objects
+  const allBvids =
+    options.bvids ??
+    (await db.getBvidList(
+      options.filter ? buildRepairBvidListQuery(options.filter) : filter,
+    ));
+  // Deduplicate by bvid to avoid concurrent processing of same video
+  const bvids = [...new Set(allBvids)];
+  logger.info(
+    `Found ${allBvids.length} videos, ${bvids.length} unique bvids to repair`,
+  );
+
+  let successCount = 0;
+  let errorCount = 0;
+  let skippedCount = 0;
+
+  const results = await runWithPool(bvids, POOL_SIZE, async (bvid, index) => {
+    return processVideo(detailsService, bvid, index + 1, bvids.length);
+  });
+
+  for (const result of results) {
+    if (result.success) successCount++;
+    else if (result.skipped) skippedCount++;
+    else errorCount++;
+  }
+
+  logger.info("\n=== Repair Complete ===");
+  logger.info(`Total: ${bvids.length}`);
+  logger.info(`Success: ${successCount}`);
+  logger.info(`Skipped: ${skippedCount}`);
+  logger.info(`Errors: ${errorCount}`);
+
+  return {
+    aidMismatchesFixed,
+    errors: errorCount,
+    skipped: skippedCount,
+    success: successCount,
+    total: bvids.length,
+  };
+}
+
+function buildRepairBvidListQuery(filter: RepairVideoFilter): BvidListQuery {
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+
+  function addParam(value: unknown): string {
+    params.push(value);
+    return `$${params.length}`;
+  }
+
+  for (const [column, value] of Object.entries(
+    normalizeFilterColumns(filter),
+  )) {
+    clauses.push(...buildColumnClauses(column as RepairFilterColumn, value));
+  }
+
+  return {
+    limit: filter.limit,
+    params,
+    where: clauses.length > 0 ? clauses.join(" AND ") : undefined,
+  };
+
+  function buildColumnClauses(
+    column: RepairFilterColumn,
+    value: RepairColumnFilterValue,
+  ): string[] {
+    const definition = FILTER_COLUMNS[column];
+    const expressions: string[] = [];
+    const columnSql = definition.sql;
+    const operator =
+      typeof value === "object" && value !== null && !Array.isArray(value)
+        ? value
+        : { eq: value };
+
+    if ("isNull" in operator) {
+      if (typeof operator.isNull !== "boolean") {
+        throw new Error(`${column}.isNull must be a boolean`);
+      }
+      expressions.push(`${columnSql} IS ${operator.isNull ? "" : "NOT "}NULL`);
+    }
+
+    if ("eq" in operator) {
+      expressions.push(
+        `${columnSql} = ${addTypedParam(operator.eq, definition)}`,
+      );
+    }
+
+    if ("in" in operator) {
+      if (definition.kind === "array" || definition.kind === "jsonb") {
+        throw new Error(`${column}.in is not supported for ${definition.kind}`);
+      }
+      expressions.push(buildInClause(columnSql, operator.in, definition));
+    }
+
+    if ("min" in operator) {
+      assertComparable(column, definition, "min");
+      expressions.push(
+        `${columnSql} >= ${addTypedParam(operator.min, definition)}`,
+      );
+    }
+
+    if ("max" in operator) {
+      assertComparable(column, definition, "max");
+      expressions.push(
+        `${columnSql} <= ${addTypedParam(operator.max, definition)}`,
+      );
+    }
+
+    if ("gte" in operator) {
+      assertComparable(column, definition, "gte");
+      expressions.push(
+        `${columnSql} >= ${addTypedParam(operator.gte, definition)}`,
+      );
+    }
+
+    if ("lte" in operator) {
+      assertComparable(column, definition, "lte");
+      expressions.push(
+        `${columnSql} <= ${addTypedParam(operator.lte, definition)}`,
+      );
+    }
+
+    if ("gt" in operator) {
+      assertComparable(column, definition, "gt");
+      expressions.push(
+        `${columnSql} > ${addTypedParam(operator.gt, definition)}`,
+      );
+    }
+
+    if ("lt" in operator) {
+      assertComparable(column, definition, "lt");
+      expressions.push(
+        `${columnSql} < ${addTypedParam(operator.lt, definition)}`,
+      );
+    }
+
+    if ("contains" in operator) {
+      expressions.push(
+        buildContainsClause(columnSql, operator.contains, definition),
+      );
+    }
+
+    if ("hasAny" in operator) {
+      expressions.push(
+        buildArrayClause(columnSql, operator.hasAny, definition, "&&"),
+      );
+    }
+
+    if ("hasAll" in operator) {
+      expressions.push(
+        buildArrayClause(columnSql, operator.hasAll, definition, "@>"),
+      );
+    }
+
+    if ("isEmpty" in operator) {
+      if (definition.kind !== "array") {
+        throw new Error(`${column}.isEmpty is only supported for arrays`);
+      }
+      if (typeof operator.isEmpty !== "boolean") {
+        throw new Error(`${column}.isEmpty must be a boolean`);
+      }
+      expressions.push(
+        `COALESCE(cardinality(${columnSql}), 0) ${
+          operator.isEmpty ? "=" : ">"
+        } 0`,
+      );
+    }
+
+    return expressions;
+  }
+
+  function assertComparable(
+    column: RepairFilterColumn,
+    definition: FilterColumnDefinition,
+    operator: string,
+  ): void {
+    if (definition.kind !== "number" && definition.kind !== "timestamp") {
+      throw new Error(
+        `${column}.${operator} is not supported for ${definition.kind}`,
+      );
+    }
+  }
+
+  function addTypedParam(
+    value: unknown,
+    definition: FilterColumnDefinition,
+  ): string {
+    return `${addParam(value)}::${definition.type}`;
+  }
+
+  function buildInClause(
+    columnSql: string,
+    values: unknown,
+    definition: FilterColumnDefinition,
+  ): string {
+    if (!Array.isArray(values) || values.length === 0) {
+      throw new Error(`${definition.apiName}.in must be a non-empty array`);
+    }
+    return `${columnSql} = ANY(${addParam(values)}::${definition.arrayType})`;
+  }
+
+  function buildContainsClause(
+    columnSql: string,
+    value: unknown,
+    definition: FilterColumnDefinition,
+  ): string {
+    if (definition.kind === "text") {
+      if (typeof value !== "string") {
+        throw new Error(`${definition.apiName}.contains must be a string`);
+      }
+      return `${columnSql} ILIKE ${addParam(`%${value}%`)}`;
+    }
+
+    if (definition.kind === "jsonb") {
+      return `${columnSql} @> ${addParam(JSON.stringify(value))}::jsonb`;
+    }
+
+    if (definition.kind === "array") {
+      return buildArrayClause(columnSql, [value], definition, "&&");
+    }
+
+    throw new Error(`${definition.apiName}.contains is not supported`);
+  }
+
+  function buildArrayClause(
+    columnSql: string,
+    values: unknown,
+    definition: FilterColumnDefinition,
+    operator: "&&" | "@>",
+  ): string {
+    if (definition.kind !== "array") {
+      throw new Error(`${definition.apiName} is not an array column`);
+    }
+
+    if (!Array.isArray(values) || values.length === 0) {
+      throw new Error(`${definition.apiName} array filter must be non-empty`);
+    }
+
+    return `${columnSql} ${operator} ${addParam(values)}::${definition.arrayType}`;
+  }
+}
+
+interface FilterColumnDefinition {
+  apiName: string;
+  arrayType: string;
+  kind: "array" | "boolean" | "jsonb" | "number" | "text" | "timestamp";
+  sql: string;
+  type: string;
+}
+
+const FILTER_COLUMNS: Record<RepairFilterColumn, FilterColumnDefinition> = {
+  aid: column("aid", "bigint", "bigint[]", "number"),
+  bvid: column("bvid", "varchar", "varchar[]", "text"),
+  copyright: column("copyright", "integer", "integer[]", "number"),
+  created_at: column("created_at", "timestamptz", "timestamptz[]", "timestamp"),
+  ctime: column("ctime", "bigint", "bigint[]", "number"),
+  description: column("description", "text", "text[]", "text"),
+  dynamic: column("dynamic", "text", "text[]", "text"),
+  extras: column("extras", "jsonb", "jsonb[]", "jsonb"),
+  is_deleted: column("is_deleted", "boolean", "boolean[]", "boolean"),
+  is_filtered: column("is_filtered", "boolean", "boolean[]", "boolean"),
+  notes: column("notes", "jsonb", "jsonb[]", "jsonb"),
+  participle: column("participle", "varchar[]", "varchar[]", "array"),
+  pic: column("pic", "varchar", "varchar[]", "text"),
+  pubdate: column("pubdate", "bigint", "bigint[]", "number"),
+  staff: column("staff", "bigint[]", "bigint[]", "array"),
+  tag: column("tag", "text", "text[]", "text"),
+  tag_new: column("tag_new", "varchar[]", "varchar[]", "array"),
+  tid_v2: column("tid_v2", "integer", "integer[]", "number"),
+  title: column("title", "varchar", "varchar[]", "text"),
+  type_id: column("type_id", "integer", "integer[]", "number"),
+  updated_at: column("updated_at", "timestamptz", "timestamptz[]", "timestamp"),
+  user_id: column("user_id", "bigint", "bigint[]", "number"),
+};
+
+function column(
+  sql: string,
+  type: string,
+  arrayType: string,
+  kind: FilterColumnDefinition["kind"],
+): FilterColumnDefinition {
+  return {
+    apiName: sql,
+    arrayType,
+    kind,
+    sql,
+    type,
+  };
+}
+
+function normalizeFilterColumns(
+  filter: RepairVideoFilter,
+): Partial<Record<RepairFilterColumn, RepairColumnFilterValue>> {
+  const { columns: nestedColumns, limit: _limit, ...topLevelColumns } = filter;
+  return { ...topLevelColumns, ...nestedColumns };
 }
 
 /**
@@ -123,7 +468,7 @@ export async function runRepairVideos(
  * them in a single transaction.  Two-pass strategy: first shift all wrong aids
  * into a safe negative range to avoid PK collisions, then assign correct aids.
  */
-async function repairAids(db: Database): Promise<void> {
+async function repairAids(db: Database): Promise<number> {
   const pool = db.getPool();
 
   const { rows: mismatches } = await pool.query(`
@@ -134,7 +479,7 @@ async function repairAids(db: Database): Promise<void> {
 
   if (mismatches.length === 0) {
     logger.info("No aid mismatches found");
-    return;
+    return 0;
   }
 
   for (const row of mismatches) {
@@ -174,4 +519,5 @@ async function repairAids(db: Database): Promise<void> {
   }
 
   logger.info(`Fixed ${mismatches.length} aid mismatches`);
+  return mismatches.length;
 }


### PR DESCRIPTION
## Summary
- split shared HTTP listener config from metrics and add repair API config
- add repair control endpoints with auth, job status, and single-job guard
- support structured repair filters over processed_videos columns, including null and non-null checks

## Verification
- pnpm build
- pnpm exec biome check src\\metrics\\server.ts src\\scripts\\repair-videos.ts src\\database\\videos.ts src\\database\\index.ts src\\config\\index.ts src\\config\\schemas\\index.ts src\\config\\schemas\\metrics.ts src\\config\\schemas\\repair.ts src\\config\\schemas\\server.ts README.md config.toml.example
- pnpm check still reports existing formatting issue in src/database/schema/collection_queue.ts