### PR TITLE
feat: batch repair video detail fetches

### DIFF
--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -139,7 +139,9 @@ export const fetchVideoFullDetailBatch = async (
   );
 
   if (response.data.code !== 0) {
-    throw new Error(`API Error: batch code ${response.data.code}`);
+    throw new Error(
+      `API Error: batch code ${response.data.code}: ${response.data.message}`,
+    );
   }
 
   return response.data.data;

--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -1,5 +1,9 @@
 import { config } from "../config";
-import type { BiliVideoFullDetailResponse } from "../types";
+import type {
+  BiliVideoBatchDetailItemResponse,
+  BiliVideoBatchDetailResponse,
+  BiliVideoFullDetailResponse,
+} from "../types";
 import { logger } from "../utils/logger";
 import {
   type RequestConfig,
@@ -114,4 +118,29 @@ export const fetchVideoFullDetail = async (params: {
     }
     throw new Error(`API Error: Fetch video full detail failed (${fullUrl})`);
   }
+};
+
+export const fetchVideoFullDetailBatch = async (
+  ids: string[],
+  concurrency?: number,
+): Promise<BiliVideoBatchDetailItemResponse[]> => {
+  if (!config.bilibili.apiProxyUrl) {
+    throw new Error("Video detail batch requires bilibili.apiProxyUrl");
+  }
+
+  const endpoint = "/view/detail/batch";
+  const response = await webInterfaceClient.post<BiliVideoBatchDetailResponse>(
+    endpoint,
+    {
+      concurrency,
+      ids,
+    },
+    { metadata: { silent: true } } as RequestConfig,
+  );
+
+  if (response.data.code !== 0) {
+    throw new Error(`API Error: batch code ${response.data.code}`);
+  }
+
+  return response.data.data;
 };

--- a/src/scripts/repair-videos.ts
+++ b/src/scripts/repair-videos.ts
@@ -202,15 +202,13 @@ async function processVideoBatch(
   const items = await fetchVideoFullDetailBatch(bvids, bvids.length);
   const itemById = new Map(items.map((item) => [item.id, item]));
 
-  return Promise.all(
-    bvids.map((bvid, index) =>
-      processBatchItem(
-        detailsService,
-        bvid,
-        itemById.get(bvid),
-        offset + index + 1,
-        total,
-      ),
+  return runWithPool(bvids, POOL_SIZE, async (bvid, index) =>
+    processBatchItem(
+      detailsService,
+      bvid,
+      itemById.get(bvid),
+      offset + index + 1,
+      total,
     ),
   );
 }

--- a/src/scripts/repair-videos.ts
+++ b/src/scripts/repair-videos.ts
@@ -1,9 +1,12 @@
+import { fetchVideoFullDetailBatch } from "../api/video.js";
 import { config } from "../config/index.js";
 import { type BvidListQuery, Database } from "../database/index.js";
 import { DetailsService } from "../services/details.service.js";
+import type { BiliVideoBatchDetailItemResponse } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 
 const POOL_SIZE = config.application.concurrencyLimit || 20;
+const VIDEO_DETAIL_BATCH_SIZE = 50;
 
 type RepairFilterColumn =
   | "aid"
@@ -106,6 +109,55 @@ async function processVideo(
   }
 }
 
+async function processBatchItem(
+  detailsService: DetailsService,
+  bvid: string,
+  item: BiliVideoBatchDetailItemResponse | undefined,
+  index: number,
+  total: number,
+): Promise<{ success: boolean; skipped: boolean }> {
+  try {
+    if (!item) {
+      throw new Error("Missing batch item response");
+    }
+
+    if (item.code !== 0) {
+      await detailsService.processVideoApiCode(bvid, item.code, item.message);
+      return { success: false, skipped: true };
+    }
+
+    if (!item.data) {
+      throw new Error("Batch item response missing data");
+    }
+
+    const { video } = await detailsService.processFetchedVideoDetail(
+      bvid,
+      item.data,
+      {
+        processRelated: false,
+      },
+    );
+
+    if (video) {
+      logger.info(
+        `[${index}/${total}] ${bvid}: aid=${BigInt(video.aid)}, user_id=${BigInt(
+          video.user_id,
+        )}`,
+      );
+      return { success: true, skipped: false };
+    }
+
+    return { success: false, skipped: true };
+  } catch (error) {
+    const errorMsg =
+      error instanceof Error
+        ? error.message
+        : JSON.stringify(error) || String(error);
+    logger.error(`[${index}/${total}] Error processing ${bvid}: ${errorMsg}`);
+    return { success: false, skipped: false };
+  }
+}
+
 /**
  * Worker pool implementation: maintains a fixed number of concurrent tasks.
  * When one task completes, the next task from the queue is started.
@@ -131,6 +183,72 @@ async function runWithPool<T, R>(
 
   await Promise.all(workers);
   return results;
+}
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+async function processVideoBatch(
+  detailsService: DetailsService,
+  bvids: string[],
+  offset: number,
+  total: number,
+): Promise<Array<{ success: boolean; skipped: boolean }>> {
+  const items = await fetchVideoFullDetailBatch(bvids, bvids.length);
+  const itemById = new Map(items.map((item) => [item.id, item]));
+
+  return Promise.all(
+    bvids.map((bvid, index) =>
+      processBatchItem(
+        detailsService,
+        bvid,
+        itemById.get(bvid),
+        offset + index + 1,
+        total,
+      ),
+    ),
+  );
+}
+
+async function runWithBatchProxy(
+  detailsService: DetailsService,
+  bvids: string[],
+): Promise<Array<{ success: boolean; skipped: boolean }> | null> {
+  if (!config.bilibili.apiProxyUrl) {
+    return null;
+  }
+
+  logger.info(
+    `Using proxy video detail batch endpoint with batch size ${VIDEO_DETAIL_BATCH_SIZE}`,
+  );
+
+  const results: Array<{ success: boolean; skipped: boolean }> = [];
+  const chunks = chunkArray(bvids, VIDEO_DETAIL_BATCH_SIZE);
+
+  try {
+    for (const [chunkIndex, chunk] of chunks.entries()) {
+      results.push(
+        ...(await processVideoBatch(
+          detailsService,
+          chunk,
+          chunkIndex * VIDEO_DETAIL_BATCH_SIZE,
+          bvids.length,
+        )),
+      );
+    }
+    return results;
+  } catch (error) {
+    logger.warn(
+      "Video detail batch request failed; falling back to single-video repair",
+      error,
+    );
+    return null;
+  }
 }
 
 export async function runRepairVideos(
@@ -182,9 +300,11 @@ export async function runRepairVideosWithDatabase(
   let errorCount = 0;
   let skippedCount = 0;
 
-  const results = await runWithPool(bvids, POOL_SIZE, async (bvid, index) => {
-    return processVideo(detailsService, bvid, index + 1, bvids.length);
-  });
+  const results =
+    (await runWithBatchProxy(detailsService, bvids)) ??
+    (await runWithPool(bvids, POOL_SIZE, async (bvid, index) => {
+      return processVideo(detailsService, bvid, index + 1, bvids.length);
+    }));
 
   for (const result of results) {
     if (result.success) successCount++;

--- a/src/services/details.service.ts
+++ b/src/services/details.service.ts
@@ -1,7 +1,12 @@
 import { getDynamic } from "../api/dynamic";
 import { fetchVideoFullDetail } from "../api/video";
 import { Database } from "../database";
-import type { BiliDynamicCard, RecommendedVideo, VideoData } from "../types";
+import type {
+  BiliDynamicCard,
+  BiliVideoDetailDataForProcessing,
+  RecommendedVideo,
+  VideoData,
+} from "../types";
 import type { DynamicData } from "../types/models/database";
 import { sharedApiRateLimiter } from "../utils/apiRateLimiter";
 import { filterVideo } from "../utils/filter";
@@ -98,15 +103,15 @@ export class DetailsService {
 
       // 3. Fetch details (with concurrency limiting)
       const release = await this.rateLimiter.acquire();
-      let videoData: VideoData;
-      let relatedVideos: RecommendedVideo[];
+      let detailData: BiliVideoDetailDataForProcessing;
       try {
-        ({ videoData, relatedVideos } = await this.fetchVideoDetailsWithRelated(
-          bvid || aid || 0,
-        ));
+        detailData = await this.fetchVideoDetails(bvid || aid || 0);
       } finally {
         release();
       }
+
+      const { videoData, relatedVideos } =
+        await this.processVideoDetailResponse(detailData);
 
       // Re-check cache using the true BVID from response (useful if we started with AID)
       if (!bvid && videoData.bvid) {
@@ -119,54 +124,11 @@ export class DetailsService {
         }
       }
 
-      // 4. Filter video
-      const filtered = await filterVideo(videoData);
-
-      // 5. Mark as processed in DB
-      await this.db.markVideoProcessed(videoData, filtered !== null);
-
-      if (!filtered) {
-        return { video: null, relatedVideos: [] };
-      }
-
-      // 6. Convert related videos to dynamics for recursive processing
-      const relatedDynamics = processRelated
-        ? this.convertRelatedToDynamics(relatedVideos)
-        : [];
-
-      return { video: filtered, relatedVideos: relatedDynamics };
+      return await this.processResolvedVideoData(videoData, relatedVideos, {
+        processRelated,
+      });
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.startsWith("VIDEO_DELETED:")
-      ) {
-        const bvidFromError = error.message.split(":")[1] || String(id);
-        logger.debug(
-          `Video ${bvidFromError} has been deleted, marking as processed`,
-        );
-        await this.db.markVideoDeleted(bvidFromError);
-        return { video: null, relatedVideos: [] };
-      }
-
-      if (
-        error instanceof Error &&
-        error.message.startsWith("VIDEO_UNAVAILABLE:")
-      ) {
-        const parts = error.message.split(":");
-        const bvidFromError = parts[1] || String(id);
-        const apiCode = Number(parts[2]);
-        const apiMessage = parts.slice(3).join(":") || "";
-        logger.debug(
-          `Video ${bvidFromError} unavailable (code ${apiCode}: ${apiMessage}), marking as deleted`,
-        );
-        await this.db.markVideoDeleted(bvidFromError, {
-          api_code: apiCode,
-          api_message: apiMessage,
-        });
-        return { video: null, relatedVideos: [] };
-      }
-
-      throw error;
+      return await this.handleVideoProcessingError(id, error);
     }
   }
 
@@ -233,22 +195,16 @@ export class DetailsService {
     return "";
   }
 
-  private async fetchVideoDetailsWithRelated(id: string | number): Promise<{
+  async processVideoDetailResponse(
+    detailData: BiliVideoDetailDataForProcessing,
+  ): Promise<{
     videoData: VideoData;
     relatedVideos: RecommendedVideo[];
   }> {
-    const params = typeof id === "number" ? { aid: id } : { bvid: id };
+    const view = detailData.View;
+    const relatedVideos = detailData.Related || [];
 
-    const fullDetail = await fetchVideoFullDetail(params);
-
-    if (!fullDetail) {
-      throw new Error(`VIDEO_DELETED:${id}`);
-    }
-
-    const view = fullDetail.data.View;
-    const relatedVideos = fullDetail.data.Related || [];
-
-    const tagString = fullDetail.data.Tags.map((t) => t.tag_name).join(";");
+    const tagString = detailData.Tags.map((t) => t.tag_name).join(";");
 
     const videoData: VideoData = {
       aid: view.aid,
@@ -262,8 +218,8 @@ export class DetailsService {
       dynamic: view.dynamic || undefined,
       pic: view.pic,
       tag: tagString,
-      tag_new: fullDetail.data.Tags?.map((t) => t.tag_name),
-      participle: fullDetail.data.participle,
+      tag_new: detailData.Tags?.map((t) => t.tag_name),
+      participle: detailData.participle,
       pubdate: view.pubdate,
       ctime: view.ctime,
       is_deleted: false,
@@ -283,7 +239,7 @@ export class DetailsService {
     };
 
     // Store the video owner (may or may not be someone we follow directly)
-    const cardInfo = fullDetail.data.Card.card;
+    const cardInfo = detailData.Card.card;
     await this.storeUser({
       mid: cardInfo.mid,
       name: cardInfo.name,
@@ -305,6 +261,125 @@ export class DetailsService {
     }
 
     return { videoData, relatedVideos };
+  }
+
+  async processFetchedVideoDetail(
+    id: string | number,
+    detailData: BiliVideoDetailDataForProcessing,
+    options: {
+      processRelated?: boolean;
+    } = {},
+  ): Promise<{
+    video: VideoData | null;
+    relatedVideos: BiliDynamicCard[];
+  }> {
+    const { processRelated = true } = options;
+
+    try {
+      const { videoData, relatedVideos } =
+        await this.processVideoDetailResponse(detailData);
+
+      return await this.processResolvedVideoData(videoData, relatedVideos, {
+        processRelated,
+      });
+    } catch (error) {
+      return await this.handleVideoProcessingError(id, error);
+    }
+  }
+
+  async processVideoApiCode(
+    id: string | number,
+    code: number,
+    message: string,
+  ): Promise<{ video: null; relatedVideos: [] }> {
+    if (code === 404 || code === -404) {
+      return await this.handleVideoProcessingError(
+        id,
+        new Error(`VIDEO_DELETED:${id}`),
+      );
+    }
+
+    if ([62002, 62004, 62012].includes(code)) {
+      return await this.handleVideoProcessingError(
+        id,
+        new Error(`VIDEO_UNAVAILABLE:${id}:${code}:${message}`),
+      );
+    }
+
+    throw new Error(`API Error: code ${code} (${message})`);
+  }
+
+  private async processResolvedVideoData(
+    videoData: VideoData,
+    relatedVideos: RecommendedVideo[],
+    options: {
+      processRelated: boolean;
+    },
+  ): Promise<{
+    video: VideoData | null;
+    relatedVideos: BiliDynamicCard[];
+  }> {
+    const filtered = await filterVideo(videoData);
+
+    await this.db.markVideoProcessed(videoData, filtered !== null);
+
+    if (!filtered) {
+      return { video: null, relatedVideos: [] };
+    }
+
+    const relatedDynamics = options.processRelated
+      ? this.convertRelatedToDynamics(relatedVideos)
+      : [];
+
+    return { video: filtered, relatedVideos: relatedDynamics };
+  }
+
+  private async handleVideoProcessingError(
+    id: string | number,
+    error: unknown,
+  ): Promise<{ video: null; relatedVideos: [] }> {
+    if (error instanceof Error && error.message.startsWith("VIDEO_DELETED:")) {
+      const bvidFromError = error.message.split(":")[1] || String(id);
+      logger.debug(
+        `Video ${bvidFromError} has been deleted, marking as processed`,
+      );
+      await this.db.markVideoDeleted(bvidFromError);
+      return { video: null, relatedVideos: [] };
+    }
+
+    if (
+      error instanceof Error &&
+      error.message.startsWith("VIDEO_UNAVAILABLE:")
+    ) {
+      const parts = error.message.split(":");
+      const bvidFromError = parts[1] || String(id);
+      const apiCode = Number(parts[2]);
+      const apiMessage = parts.slice(3).join(":") || "";
+      logger.debug(
+        `Video ${bvidFromError} unavailable (code ${apiCode}: ${apiMessage}), marking as deleted`,
+      );
+      await this.db.markVideoDeleted(bvidFromError, {
+        api_code: apiCode,
+        api_message: apiMessage,
+      });
+      return { video: null, relatedVideos: [] };
+    }
+
+    throw error;
+  }
+
+  private async fetchVideoDetails(
+    id: string | number,
+  ): Promise<BiliVideoDetailDataForProcessing> {
+    const params = typeof id === "number" ? { aid: id } : { bvid: id };
+
+    const fullDetail = await fetchVideoFullDetail(params);
+
+    if (!fullDetail) {
+      throw new Error(`VIDEO_DELETED:${id}`);
+    }
+
+    return fullDetail.data;
   }
 
   /**

--- a/src/types/bilibili/video.ts
+++ b/src/types/bilibili/video.ts
@@ -194,6 +194,110 @@ export interface RecommendedVideo {
   tname: string;
 }
 
+export interface BiliVideoDetailDataForProcessing {
+  View: {
+    aid: bigint;
+    bvid: string;
+    cid: number;
+    copyright: number;
+    ctime: number;
+    desc: string;
+    dimension: BiliVideoDimension;
+    duration: number;
+    dynamic: string;
+    owner: BiliVideoOwner;
+    pic: string;
+    pubdate: number;
+    rights: BiliVideoRights;
+    state: number;
+    tid: number;
+    tid_v2?: number;
+    title: string;
+    videos: number;
+    mission_id?: number;
+    staff?: Array<{
+      mid: bigint;
+      title?: string;
+      name?: string;
+      face?: string;
+      follower?: number;
+    }>;
+    ugc_season?: {
+      id: number;
+      title?: string;
+      mid?: number;
+      intro?: string;
+      ep_count?: number;
+    };
+    argue_info?: {
+      argue_msg: string;
+      argue_type: number;
+      argue_link: string;
+    };
+    honor_reply?: {
+      honor?: Array<{
+        aid?: number;
+        type: number;
+        desc: string;
+        weekly_recommend_num: number;
+      }>;
+    };
+  };
+  Card: {
+    card: {
+      mid: string;
+      name: string;
+      face: string;
+      fans: number;
+      attention?: number;
+      sign: string;
+      level_info?: {
+        current_level?: number;
+      };
+      Official?: {
+        role?: number;
+        title: string;
+        desc?: string;
+        type: number;
+      };
+      official_verify?: {
+        type: number;
+        desc: string;
+      };
+    };
+    following?: boolean;
+    archive_count?: number;
+    article_count?: number;
+    follower?: number;
+  };
+  Tags: Array<{
+    tag_id?: number;
+    tag_name: string;
+    cover?: string;
+    likes?: number;
+    hates?: number;
+    attribute?: number;
+    is_activity?: number;
+    uri?: string;
+    tag_type?: string;
+  }>;
+  Related?: RecommendedVideo[];
+  participle?: string[];
+}
+
+export interface BiliVideoBatchDetailItemResponse {
+  id: string;
+  code: number;
+  message: string;
+  data?: BiliVideoDetailDataForProcessing;
+}
+
+export interface BiliVideoBatchDetailResponse {
+  code: number;
+  message: string;
+  data: BiliVideoBatchDetailItemResponse[];
+}
+
 /**
  * Full video detail response including related videos
  */
@@ -201,7 +305,7 @@ export interface BiliVideoFullDetailResponse {
   code: number;
   message: string;
   ttl: number;
-  data: {
+  data: BiliVideoDetailDataForProcessing & {
     View: {
       aid: bigint;
       bvid: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,9 @@ export type { BiliVideoDetailResponse, VideoTagResponse } from "./api/video";
 export type { BiliDynamicCard } from "./bilibili/dynamic";
 // Bilibili video types
 export type {
+  BiliVideoBatchDetailItemResponse,
+  BiliVideoBatchDetailResponse,
+  BiliVideoDetailDataForProcessing,
   BiliVideoFullDetailResponse,
   RecommendedVideo,
 } from "./bilibili/video";


### PR DESCRIPTION
Uses the newly released http-proxy-ipv6-pool 2.1.2 batch endpoint from repair mode only. When bilibili.apiProxyUrl is configured, repair groups BVIDs into batches of 50 and calls POST /x/web-interface/view/detail/batch so dynamic-proxy sends one cross-border request per batch while proxy-bilibili fans out upstream. If the batch endpoint fails as a whole, repair falls back to the existing single-video path. Normal tracker and minute flows remain unchanged. Verification: pnpm check; pnpm build; git diff --check.