### PR TITLE
feat: collect and store video subtitles

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -74,6 +74,13 @@ bootstrap_tid_v2_allowlist = [2022, 2061]
 processed_backfill_new_video_age_days = 7
 collection_business_timezone = "Asia/Shanghai"
 
+[subtitle]
+# Subtitle collection is global, single-consumer, and direct-to-Bilibili with session cookies.
+enabled = false
+view_threshold = 10000
+fetch_interval_ms = 60000
+max_retries = 3
+
 [processing]
 [processing.features]
 # Feature toggles

--- a/migrations/002_subtitle_tables.sql
+++ b/migrations/002_subtitle_tables.sql
@@ -1,0 +1,24 @@
+-- Migration: subtitle storage backfill.
+--
+-- Deployment order:
+--   1. Deploy code.
+--   2. Run --init-schema to create video_subtitles, subtitle_state, helper
+--      functions, and gate-crossing trigger.
+--   3. Run this migration to mark already-eligible videos as pending.
+--
+-- Future videos are marked by schema functions/triggers when their state row is
+-- updated, but videos that crossed 10k before this feature existed need this
+-- one-time backfill.
+
+BEGIN;
+
+UPDATE video_collection_state
+SET subtitle_state = fn_next_subtitle_state(subtitle_state, last_view, NULL),
+    updated_at = now()
+WHERE subtitle_state IS DISTINCT FROM fn_next_subtitle_state(
+  subtitle_state,
+  last_view,
+  NULL
+);
+
+COMMIT;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -410,6 +410,30 @@ export function createAccountDynamicClient(
   });
 }
 
+export function createAccountWebInterfaceClient(
+  cookieJar: CookieJar,
+  accountCookieFilePath: string,
+  stateManager: StateManager,
+): AxiosInstance {
+  return createClient("https://api.bilibili.com/x/web-interface", {
+    cookieJar,
+    cookieFilePath: accountCookieFilePath,
+    stateManager,
+  });
+}
+
+export function createAccountPlayerClient(
+  cookieJar: CookieJar,
+  accountCookieFilePath: string,
+  stateManager: StateManager,
+): AxiosInstance {
+  return createClient("https://api.bilibili.com/x/player", {
+    cookieJar,
+    cookieFilePath: accountCookieFilePath,
+    stateManager,
+  });
+}
+
 export const dynamicClient = createClient(
   "https://api.vc.bilibili.com/dynamic_svr/v1/dynamic_svr",
 );
@@ -431,6 +455,10 @@ export const webInterfaceClient = createClient(
 // Direct client without proxy for fallback
 export const webInterfaceDirectClient = createClient(
   "https://api.bilibili.com/x/web-interface",
+);
+
+export const playerDirectClient = createClient(
+  "https://api.bilibili.com/x/player",
 );
 
 export const medialistClient = createClient(

--- a/src/api/subtitle.ts
+++ b/src/api/subtitle.ts
@@ -92,12 +92,11 @@ export async function fetchPlayerSubtitleTracks(
   bvid: string,
   cid: bigint,
 ): Promise<BiliSubtitleTrackInfo[]> {
-  const query = await buildSignedQuery({ bvid, cid: cid.toString() });
-  let endRequest: (() => number) | null = null;
+  const endRequest = subtitleApiRequestDurationSeconds.startTimer({
+    endpoint: "player_wbi_v2",
+  });
   try {
-    endRequest = subtitleApiRequestDurationSeconds.startTimer({
-      endpoint: "player_wbi_v2",
-    });
+    const query = await buildSignedQuery({ bvid, cid: cid.toString() });
     const response = await client.get<BiliPlayerWbiV2Response>(
       `/wbi/v2?${query}`,
       {
@@ -123,7 +122,7 @@ export async function fetchPlayerSubtitleTracks(
     });
     throw error;
   } finally {
-    endRequest?.();
+    endRequest();
   }
 }
 

--- a/src/api/subtitle.ts
+++ b/src/api/subtitle.ts
@@ -1,0 +1,107 @@
+import type { AxiosInstance } from "axios";
+import axios from "axios";
+import type { BiliVideoDetailResponse } from "../types/api/video.js";
+import type {
+  BiliPlayerWbiV2Response,
+  BiliSubtitleJson,
+  BiliSubtitleTrackInfo,
+} from "../types/bilibili/subtitle.js";
+import { logger } from "../utils/logger.js";
+import type { RequestConfig } from "./client.js";
+import { buildSignedQuery } from "./signatures/wbiSignature.js";
+
+const UNAVAILABLE_CODES = new Set([404, -404, 62002, 62004, 62012]);
+
+export interface SubtitleVideoPage {
+  cid: bigint;
+  page: number;
+  part: string;
+}
+
+export interface SubtitleVideoView {
+  aid: bigint;
+  bvid: string;
+  pages: SubtitleVideoPage[];
+}
+
+function isUnavailableCode(code: number): boolean {
+  return UNAVAILABLE_CODES.has(code);
+}
+
+function normalizeSubtitleUrl(url: string): string {
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+  if (url.startsWith("//")) return `https:${url}`;
+  return `https://${url}`;
+}
+
+export async function fetchSubtitleVideoView(
+  client: AxiosInstance,
+  aid: bigint,
+): Promise<SubtitleVideoView | null> {
+  const response = await client.get<BiliVideoDetailResponse>("/view", {
+    params: { aid: aid.toString() },
+    ...({ metadata: { silent: true } } as RequestConfig),
+  });
+
+  if (response.data.code === 0) {
+    return {
+      aid: BigInt(response.data.data.aid),
+      bvid: response.data.data.bvid,
+      pages: response.data.data.pages.map((page) => ({
+        cid: BigInt(page.cid),
+        page: page.page,
+        part: page.part,
+      })),
+    };
+  }
+
+  if (isUnavailableCode(response.data.code)) {
+    logger.debug(
+      `Subtitle view API returned unavailable code ${response.data.code} for aid ${aid}`,
+    );
+    return null;
+  }
+
+  throw new Error(
+    `Subtitle view API error for aid ${aid}: code ${response.data.code}`,
+  );
+}
+
+export async function fetchPlayerSubtitleTracks(
+  client: AxiosInstance,
+  bvid: string,
+  cid: bigint,
+): Promise<BiliSubtitleTrackInfo[]> {
+  const query = await buildSignedQuery({ bvid, cid: cid.toString() });
+  const response = await client.get<BiliPlayerWbiV2Response>(
+    `/wbi/v2?${query}`,
+    {
+      ...({ metadata: { silent: true } } as RequestConfig),
+    },
+  );
+
+  if (response.data.code !== 0) {
+    throw new Error(
+      `Player subtitle API error for ${bvid}/${cid}: code ${response.data.code}`,
+    );
+  }
+
+  return response.data.data?.subtitle?.subtitles ?? [];
+}
+
+export async function fetchSubtitleJson(
+  subtitleUrl: string,
+): Promise<BiliSubtitleJson> {
+  const url = normalizeSubtitleUrl(subtitleUrl);
+  const response = await axios.get<BiliSubtitleJson>(url, {
+    headers: {
+      Referer: "https://www.bilibili.com/",
+    },
+  });
+
+  if (!Array.isArray(response.data.body)) {
+    throw new Error(`Invalid subtitle JSON from ${url}`);
+  }
+
+  return response.data;
+}

--- a/src/api/subtitle.ts
+++ b/src/api/subtitle.ts
@@ -1,5 +1,9 @@
 import type { AxiosInstance } from "axios";
 import axios from "axios";
+import {
+  subtitleApiRequestDurationSeconds,
+  subtitleApiRequestsTotal,
+} from "../metrics/registry.js";
 import type { BiliVideoDetailResponse } from "../types/api/video.js";
 import type {
   BiliPlayerWbiV2Response,
@@ -38,33 +42,49 @@ export async function fetchSubtitleVideoView(
   client: AxiosInstance,
   aid: bigint,
 ): Promise<SubtitleVideoView | null> {
-  const response = await client.get<BiliVideoDetailResponse>("/view", {
-    params: { aid: aid.toString() },
-    ...({ metadata: { silent: true } } as RequestConfig),
+  const endRequest = subtitleApiRequestDurationSeconds.startTimer({
+    endpoint: "view",
   });
+  try {
+    const response = await client.get<BiliVideoDetailResponse>("/view", {
+      params: { aid: aid.toString() },
+      ...({ metadata: { silent: true } } as RequestConfig),
+    });
 
-  if (response.data.code === 0) {
-    return {
-      aid: BigInt(response.data.data.aid),
-      bvid: response.data.data.bvid,
-      pages: response.data.data.pages.map((page) => ({
-        cid: BigInt(page.cid),
-        page: page.page,
-        part: page.part,
-      })),
-    };
-  }
+    if (response.data.code === 0) {
+      const view = {
+        aid: BigInt(response.data.data.aid),
+        bvid: response.data.data.bvid,
+        pages: response.data.data.pages.map((page) => ({
+          cid: BigInt(page.cid),
+          page: page.page,
+          part: page.part,
+        })),
+      };
+      subtitleApiRequestsTotal.inc({ endpoint: "view", result: "success" });
+      return view;
+    }
 
-  if (isUnavailableCode(response.data.code)) {
-    logger.debug(
-      `Subtitle view API returned unavailable code ${response.data.code} for aid ${aid}`,
+    if (isUnavailableCode(response.data.code)) {
+      subtitleApiRequestsTotal.inc({
+        endpoint: "view",
+        result: "unavailable",
+      });
+      logger.debug(
+        `Subtitle view API returned unavailable code ${response.data.code} for aid ${aid}`,
+      );
+      return null;
+    }
+
+    throw new Error(
+      `Subtitle view API error for aid ${aid}: code ${response.data.code}`,
     );
-    return null;
+  } catch (error) {
+    subtitleApiRequestsTotal.inc({ endpoint: "view", result: "error" });
+    throw error;
+  } finally {
+    endRequest();
   }
-
-  throw new Error(
-    `Subtitle view API error for aid ${aid}: code ${response.data.code}`,
-  );
 }
 
 export async function fetchPlayerSubtitleTracks(
@@ -73,35 +93,70 @@ export async function fetchPlayerSubtitleTracks(
   cid: bigint,
 ): Promise<BiliSubtitleTrackInfo[]> {
   const query = await buildSignedQuery({ bvid, cid: cid.toString() });
-  const response = await client.get<BiliPlayerWbiV2Response>(
-    `/wbi/v2?${query}`,
-    {
-      ...({ metadata: { silent: true } } as RequestConfig),
-    },
-  );
-
-  if (response.data.code !== 0) {
-    throw new Error(
-      `Player subtitle API error for ${bvid}/${cid}: code ${response.data.code}`,
+  let endRequest: (() => number) | null = null;
+  try {
+    endRequest = subtitleApiRequestDurationSeconds.startTimer({
+      endpoint: "player_wbi_v2",
+    });
+    const response = await client.get<BiliPlayerWbiV2Response>(
+      `/wbi/v2?${query}`,
+      {
+        ...({ metadata: { silent: true } } as RequestConfig),
+      },
     );
-  }
 
-  return response.data.data?.subtitle?.subtitles ?? [];
+    if (response.data.code !== 0) {
+      throw new Error(
+        `Player subtitle API error for ${bvid}/${cid}: code ${response.data.code}`,
+      );
+    }
+
+    subtitleApiRequestsTotal.inc({
+      endpoint: "player_wbi_v2",
+      result: "success",
+    });
+    return response.data.data?.subtitle?.subtitles ?? [];
+  } catch (error) {
+    subtitleApiRequestsTotal.inc({
+      endpoint: "player_wbi_v2",
+      result: "error",
+    });
+    throw error;
+  } finally {
+    endRequest?.();
+  }
 }
 
 export async function fetchSubtitleJson(
   subtitleUrl: string,
 ): Promise<BiliSubtitleJson> {
-  const url = normalizeSubtitleUrl(subtitleUrl);
-  const response = await axios.get<BiliSubtitleJson>(url, {
-    headers: {
-      Referer: "https://www.bilibili.com/",
-    },
+  const endRequest = subtitleApiRequestDurationSeconds.startTimer({
+    endpoint: "subtitle_json",
   });
+  try {
+    const url = normalizeSubtitleUrl(subtitleUrl);
+    const response = await axios.get<BiliSubtitleJson>(url, {
+      headers: {
+        Referer: "https://www.bilibili.com/",
+      },
+    });
 
-  if (!Array.isArray(response.data.body)) {
-    throw new Error(`Invalid subtitle JSON from ${url}`);
+    if (!Array.isArray(response.data.body)) {
+      throw new Error(`Invalid subtitle JSON from ${url}`);
+    }
+
+    subtitleApiRequestsTotal.inc({
+      endpoint: "subtitle_json",
+      result: "success",
+    });
+    return response.data;
+  } catch (error) {
+    subtitleApiRequestsTotal.inc({
+      endpoint: "subtitle_json",
+      result: "error",
+    });
+    throw error;
+  } finally {
+    endRequest();
   }
-
-  return response.data;
 }

--- a/src/api/subtitle.ts
+++ b/src/api/subtitle.ts
@@ -92,11 +92,12 @@ export async function fetchPlayerSubtitleTracks(
   bvid: string,
   cid: bigint,
 ): Promise<BiliSubtitleTrackInfo[]> {
-  const endRequest = subtitleApiRequestDurationSeconds.startTimer({
-    endpoint: "player_wbi_v2",
-  });
+  const query = await buildSignedQuery({ bvid, cid: cid.toString() });
+  let endRequest: (() => number) | null = null;
   try {
-    const query = await buildSignedQuery({ bvid, cid: cid.toString() });
+    endRequest = subtitleApiRequestDurationSeconds.startTimer({
+      endpoint: "player_wbi_v2",
+    });
     const response = await client.get<BiliPlayerWbiV2Response>(
       `/wbi/v2?${query}`,
       {
@@ -122,7 +123,7 @@ export async function fetchPlayerSubtitleTracks(
     });
     throw error;
   } finally {
-    endRequest();
+    endRequest?.();
   }
 }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -13,12 +13,14 @@ import {
   createMinuteConfig,
   createNotificationsConfig,
   createProcessingConfig,
+  createSubtitleConfig,
   databaseSchema,
   exportSchema,
   metricsSchema,
   minuteSchema,
   notificationsSchema,
   processingSchema,
+  subtitleSchema,
 } from "./schemas";
 
 let tomlData: unknown = {};
@@ -80,6 +82,7 @@ const configSchema = z.object({
   processing: processingSchema,
   export: exportSchema,
   metrics: metricsSchema,
+  subtitle: subtitleSchema,
   notifications: notificationsSchema,
 });
 
@@ -91,5 +94,6 @@ export const config = configSchema.parse({
   processing: createProcessingConfig(getConfigValue),
   export: createExportConfig(getConfigValue),
   metrics: createMetricsConfig(getConfigValue),
+  subtitle: createSubtitleConfig(getConfigValue),
   notifications: createNotificationsConfig(getConfigValue),
 });

--- a/src/config/schemas/index.ts
+++ b/src/config/schemas/index.ts
@@ -9,3 +9,4 @@ export {
   notificationsSchema,
 } from "./notifications";
 export { createProcessingConfig, processingSchema } from "./processing";
+export { createSubtitleConfig, subtitleSchema } from "./subtitle";

--- a/src/config/schemas/subtitle.ts
+++ b/src/config/schemas/subtitle.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+const configBoolean = z.preprocess((value) => {
+  if (typeof value !== "string") return value;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}, z.boolean());
+
+export const subtitleSchema = z.object({
+  enabled: configBoolean.default(false),
+  viewThreshold: z.coerce.number().int().positive().default(10_000),
+  fetchIntervalMs: z.coerce.number().int().positive().default(60_000),
+  maxRetries: z.coerce.number().int().positive().default(3),
+});
+
+export type SubtitleConfig = z.infer<typeof subtitleSchema>;
+
+export function createSubtitleConfig(
+  getConfigValue: (
+    tomlPath: string[],
+    envKey: string,
+    // biome-ignore lint/suspicious/noExplicitAny: Config values from TOML/env are inherently untyped and validated by zod
+    defaultValue?: any,
+    // biome-ignore lint/suspicious/noExplicitAny: Config values from TOML/env are inherently untyped and validated by zod
+  ) => any,
+): SubtitleConfig {
+  return subtitleSchema.parse({
+    enabled: getConfigValue(["subtitle", "enabled"], "SUBTITLE_ENABLED", false),
+    viewThreshold: getConfigValue(
+      ["subtitle", "view_threshold"],
+      "SUBTITLE_VIEW_THRESHOLD",
+      10_000,
+    ),
+    fetchIntervalMs: getConfigValue(
+      ["subtitle", "fetch_interval_ms"],
+      "SUBTITLE_FETCH_INTERVAL_MS",
+      60_000,
+    ),
+    maxRetries: getConfigValue(
+      ["subtitle", "max_retries"],
+      "SUBTITLE_MAX_RETRIES",
+      3,
+    ),
+  });
+}

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -2,7 +2,11 @@ import type { AxiosInstance } from "axios";
 import type { CookieJar } from "tough-cookie";
 import {
   createAccountDynamicClient,
+  createAccountPlayerClient,
+  createAccountWebInterfaceClient,
   dynamicClient as globalDynamicClient,
+  playerDirectClient as globalPlayerClient,
+  webInterfaceDirectClient as globalWebInterfaceClient,
 } from "../api/client";
 import { config } from "../config";
 import {
@@ -24,6 +28,10 @@ export interface AccountContext {
   stateManager: StateManager;
   /** Authenticated dynamic API client for this account */
   dynamicClient: AxiosInstance;
+  /** Authenticated direct web-interface client for this account */
+  webInterfaceClient: AxiosInstance;
+  /** Authenticated direct player client for this account */
+  playerClient: AxiosInstance;
 }
 
 let _accounts: AccountContext[] | null = null;
@@ -67,6 +75,16 @@ export function loadAccounts(): AccountContext[] {
         filePath,
         stateManager,
       );
+      const webInterfaceClient = createAccountWebInterfaceClient(
+        jar,
+        filePath,
+        stateManager,
+      );
+      const playerClient = createAccountPlayerClient(
+        jar,
+        filePath,
+        stateManager,
+      );
 
       logger.info(`Loaded account uid=${uid} from ${filePath}`);
       return {
@@ -75,6 +93,8 @@ export function loadAccounts(): AccountContext[] {
         cookieFilePath: filePath,
         stateManager,
         dynamicClient: client,
+        webInterfaceClient,
+        playerClient,
       };
     });
   } else {
@@ -87,6 +107,8 @@ export function loadAccounts(): AccountContext[] {
         cookieFilePath: null,
         stateManager: new StateManager("./state.json"),
         dynamicClient: globalDynamicClient,
+        webInterfaceClient: globalWebInterfaceClient,
+        playerClient: globalPlayerClient,
       },
     ];
   }

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -6,6 +6,10 @@ import {
   dbQueryErrorsTotal,
 } from "../metrics/registry.js";
 import type {
+  SubtitleState,
+  VideoSubtitleRow,
+} from "../types/bilibili/subtitle.js";
+import type {
   DatabaseStats,
   DiscoveredUserData,
   DynamicData,
@@ -73,6 +77,18 @@ import {
 } from "./recommendations.js";
 import { initializeSchema } from "./schema/index.js";
 import { getStats } from "./stats.js";
+import {
+  aidHasManualSubtitle,
+  cidHasManualSubtitle,
+  getSubtitlesByAid,
+  getSubtitlesByCid,
+  recordSubtitleFailure,
+  type SubtitleJob,
+  selectNextSubtitleJob,
+  type UpsertSubtitleInput,
+  updateSubtitleState,
+  upsertSubtitlesBatch,
+} from "./subtitles.js";
 import {
   addDiscoveredUser,
   getTopDiscoveredUsers,
@@ -294,6 +310,59 @@ export class Database {
     limit?: number,
   ): Promise<VideoSnapshot[]> {
     return getVideoHistory(this.ensurePool(), bvid, limit);
+  }
+
+  // ===== Subtitle Operations =====
+
+  public async selectNextSubtitleJob(): Promise<SubtitleJob | null> {
+    return selectNextSubtitleJob(this.ensurePool());
+  }
+
+  public async updateSubtitleState(
+    aid: bigint,
+    state: SubtitleState,
+  ): Promise<void> {
+    return updateSubtitleState(this.ensurePool(), aid, state);
+  }
+
+  public async recordSubtitleFailure(
+    aid: bigint,
+    errorMessage: string,
+  ): Promise<{ state: SubtitleState | null; failureCount: number }> {
+    return recordSubtitleFailure(
+      this.ensurePool(),
+      aid,
+      errorMessage,
+      config.subtitle.maxRetries,
+    );
+  }
+
+  public async upsertSubtitlesBatch(
+    inputs: UpsertSubtitleInput[],
+  ): Promise<number> {
+    return upsertSubtitlesBatch(this.ensurePool(), inputs);
+  }
+
+  public async getSubtitlesByAid(aid: bigint): Promise<VideoSubtitleRow[]> {
+    return getSubtitlesByAid(this.ensurePool(), aid);
+  }
+
+  public async getSubtitlesByCid(
+    aid: bigint,
+    cid: bigint,
+  ): Promise<VideoSubtitleRow[]> {
+    return getSubtitlesByCid(this.ensurePool(), aid, cid);
+  }
+
+  public async cidHasManualSubtitle(
+    aid: bigint,
+    cid: bigint,
+  ): Promise<boolean> {
+    return cidHasManualSubtitle(this.ensurePool(), aid, cid);
+  }
+
+  public async aidHasManualSubtitle(aid: bigint): Promise<boolean> {
+    return aidHasManualSubtitle(this.ensurePool(), aid);
   }
 
   // ===== Dynamic Operations =====

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -80,7 +80,7 @@ import {
 import { initializeSchema } from "./schema/index.js";
 import { getStats } from "./stats.js";
 import {
-  aidHasManualSubtitle,
+  cidHasAiSubtitle,
   cidHasManualSubtitle,
   getSubtitleStateCounts,
   getSubtitlesByAid,
@@ -373,8 +373,8 @@ export class Database {
     return cidHasManualSubtitle(this.ensurePool(), aid, cid);
   }
 
-  public async aidHasManualSubtitle(aid: bigint): Promise<boolean> {
-    return aidHasManualSubtitle(this.ensurePool(), aid);
+  public async cidHasAiSubtitle(aid: bigint, cid: bigint): Promise<boolean> {
+    return cidHasAiSubtitle(this.ensurePool(), aid, cid);
   }
 
   // ===== Dynamic Operations =====

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -90,6 +90,7 @@ import {
   type SubtitleStateMetric,
   selectNextSubtitleJob,
   type UpsertSubtitleInput,
+  type UpsertSubtitleResult,
   updateSubtitleState,
   upsertSubtitlesBatch,
 } from "./subtitles.js";
@@ -350,7 +351,7 @@ export class Database {
 
   public async upsertSubtitlesBatch(
     inputs: UpsertSubtitleInput[],
-  ): Promise<number> {
+  ): Promise<UpsertSubtitleResult> {
     return upsertSubtitlesBatch(this.ensurePool(), inputs);
   }
 

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -82,10 +82,12 @@ import { getStats } from "./stats.js";
 import {
   aidHasManualSubtitle,
   cidHasManualSubtitle,
+  getSubtitleStateCounts,
   getSubtitlesByAid,
   getSubtitlesByCid,
   recordSubtitleFailure,
   type SubtitleJob,
+  type SubtitleStateMetric,
   selectNextSubtitleJob,
   type UpsertSubtitleInput,
   updateSubtitleState,
@@ -319,6 +321,12 @@ export class Database {
 
   public async selectNextSubtitleJob(): Promise<SubtitleJob | null> {
     return selectNextSubtitleJob(this.ensurePool());
+  }
+
+  public async getSubtitleStateCounts(): Promise<
+    Partial<Record<SubtitleStateMetric, number>>
+  > {
+    return getSubtitleStateCounts(this.ensurePool());
   }
 
   public async updateSubtitleState(

--- a/src/database/schema/collection_queue.ts
+++ b/src/database/schema/collection_queue.ts
@@ -13,12 +13,24 @@ export async function initCollectionQueueSchema(pool: Pool): Promise<void> {
   await pool.query(`DROP TABLE IF EXISTS video_collection_queue CASCADE`);
 
   // ── Drop legacy queue-only functions ─────────────────────────────
-  await pool.query(`DROP FUNCTION IF EXISTS fn_advance_abandoned_minute_collection_state(timestamptz)`);
-  await pool.query(`DROP FUNCTION IF EXISTS fn_enqueue_video_collection_tasks(timestamptz, integer)`);
-  await pool.query(`DROP FUNCTION IF EXISTS fn_enqueue_video_collection_gate_tasks(timestamptz, interval, numeric, bigint, integer, text)`);
-  await pool.query(`DROP FUNCTION IF EXISTS fn_claim_video_collection_tasks(timestamptz, integer, interval)`);
-  await pool.query(`DROP FUNCTION IF EXISTS fn_ack_video_collection_tasks(bigint[], timestamptz)`);
-  await pool.query(`DROP FUNCTION IF EXISTS fn_fail_video_collection_tasks(bigint[], timestamptz)`);
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_advance_abandoned_minute_collection_state(timestamptz)`,
+  );
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_enqueue_video_collection_tasks(timestamptz, integer)`,
+  );
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_enqueue_video_collection_gate_tasks(timestamptz, interval, numeric, bigint, integer, text)`,
+  );
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_claim_video_collection_tasks(timestamptz, integer, interval)`,
+  );
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_ack_video_collection_tasks(bigint[], timestamptz)`,
+  );
+  await pool.query(
+    `DROP FUNCTION IF EXISTS fn_fail_video_collection_tasks(bigint[], timestamptz)`,
+  );
 
   // ── Gate crossing records (still used by triggers) ───────────────
   await pool.query(`

--- a/src/database/schema/collection_state.ts
+++ b/src/database/schema/collection_state.ts
@@ -82,18 +82,20 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
   `);
 
   await pool.query(`
-    DO $$ BEGIN
-      ALTER TABLE video_collection_state
-      ADD CONSTRAINT chk_subtitle_state
-        CHECK (
-          subtitle_state IS NULL
-          OR subtitle_state IN (
-            'pending', 'has_manual', 'ai_only', 'no_subtitle', 'skipped'
-          )
-        );
-    EXCEPTION
-      WHEN duplicate_object THEN NULL;
-    END $$
+    ALTER TABLE video_collection_state
+    DROP CONSTRAINT IF EXISTS chk_subtitle_state
+  `);
+
+  await pool.query(`
+    ALTER TABLE video_collection_state
+    ADD CONSTRAINT chk_subtitle_state
+      CHECK (
+        subtitle_state IS NULL
+        OR subtitle_state IN (
+          'pending', 'has_manual', 'partial_manual', 'ai_only',
+          'no_subtitle', 'skipped'
+        )
+      )
   `);
 
   await pool.query(`
@@ -125,7 +127,10 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
       SELECT CASE
         WHEN p_current_state IN ('has_manual', 'skipped') THEN p_current_state
         WHEN fn_is_subtitle_gate(p_crossed_gate)
-          AND (p_current_state IS NULL OR p_current_state IN ('ai_only', 'no_subtitle'))
+          AND (
+            p_current_state IS NULL
+            OR p_current_state IN ('partial_manual', 'ai_only', 'no_subtitle')
+          )
         THEN 'pending'
         WHEN p_current_state IS NULL AND COALESCE(p_last_view, 0) >= ${config.subtitle.viewThreshold} THEN 'pending'
         ELSE p_current_state

--- a/src/database/schema/collection_state.ts
+++ b/src/database/schema/collection_state.ts
@@ -61,6 +61,78 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
     ADD COLUMN IF NOT EXISTS last_view_change_at timestamptz
   `);
 
+  await pool.query(`
+    ALTER TABLE video_collection_state
+    ADD COLUMN IF NOT EXISTS subtitle_state varchar(20) DEFAULT NULL
+  `);
+
+  await pool.query(`
+    ALTER TABLE video_collection_state
+    ADD COLUMN IF NOT EXISTS subtitle_failure_count integer NOT NULL DEFAULT 0
+  `);
+
+  await pool.query(`
+    ALTER TABLE video_collection_state
+    ADD COLUMN IF NOT EXISTS last_subtitle_error_at timestamptz
+  `);
+
+  await pool.query(`
+    ALTER TABLE video_collection_state
+    ADD COLUMN IF NOT EXISTS subtitle_last_error text
+  `);
+
+  await pool.query(`
+    DO $$ BEGIN
+      ALTER TABLE video_collection_state
+      ADD CONSTRAINT chk_subtitle_state
+        CHECK (
+          subtitle_state IS NULL
+          OR subtitle_state IN (
+            'pending', 'has_manual', 'ai_only', 'no_subtitle', 'skipped'
+          )
+        );
+    EXCEPTION
+      WHEN duplicate_object THEN NULL;
+    END $$
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_video_collection_subtitle_pending
+    ON video_collection_state(last_view DESC)
+    WHERE subtitle_state = 'pending'
+  `);
+
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION fn_is_subtitle_gate(
+      p_gate bigint
+    ) RETURNS boolean AS $$
+      SELECT CASE
+        WHEN p_gate IS NULL THEN false
+        WHEN p_gate = 10000 THEN true
+        WHEN p_gate < 1000000 AND p_gate % 100000 = 0 THEN true
+        WHEN p_gate >= 1000000 AND p_gate % 1000000 = 0 THEN true
+        ELSE false
+      END
+    $$ LANGUAGE sql IMMUTABLE PARALLEL SAFE
+  `);
+
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION fn_next_subtitle_state(
+      p_current_state text,
+      p_last_view bigint,
+      p_crossed_gate bigint DEFAULT NULL
+    ) RETURNS text AS $$
+      SELECT CASE
+        WHEN p_current_state IN ('has_manual', 'skipped') THEN p_current_state
+        WHEN fn_is_subtitle_gate(p_crossed_gate)
+          AND (p_current_state IS NULL OR p_current_state IN ('ai_only', 'no_subtitle'))
+        THEN 'pending'
+        WHEN p_current_state IS NULL AND COALESCE(p_last_view, 0) >= ${config.subtitle.viewThreshold} THEN 'pending'
+        ELSE p_current_state
+      END
+    $$ LANGUAGE sql IMMUTABLE PARALLEL SAFE
+  `);
+
   // Bilibili view counters refresh roughly every 75 s (varies 60-90 s).
   // Polling faster than that just retrieves stale values, so the effective
   // base interval is floored to 75 s.  Only affects priority = 1
@@ -281,7 +353,7 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
       INSERT INTO video_collection_state (
         aid, latest_daily_delta, weekly_avg_daily_delta, daily_delta_source,
         priority, next_minute_due_at, last_daily_record_date, last_view,
-        next_gate_value, updated_at
+        next_gate_value, subtitle_state, updated_at
       )
       SELECT
         c.aid, c.latest_daily_delta, c.weekly_avg_daily_delta, c.daily_delta_source,
@@ -292,6 +364,7 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
         v_today,
         c.last_view,
         c.next_gate_value,
+        fn_next_subtitle_state(NULL, c.last_view, c.crossed_gate),
         p_now
       FROM calculated c
       ON CONFLICT (aid) DO UPDATE SET
@@ -329,6 +402,15 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
           THEN EXCLUDED.next_gate_value
           ELSE video_collection_state.next_gate_value
         END,
+        subtitle_state         = fn_next_subtitle_state(
+          video_collection_state.subtitle_state,
+          COALESCE(greatest(EXCLUDED.last_view, video_collection_state.last_view), EXCLUDED.last_view, video_collection_state.last_view),
+          (
+            SELECT c.crossed_gate
+            FROM calculated c
+            WHERE c.aid = EXCLUDED.aid
+          )
+        ),
         updated_at             = p_now;
 
       GET DIAGNOSTICS changed_count = ROW_COUNT;
@@ -466,6 +548,7 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
         priority,
         bootstrap_until,
         next_minute_due_at,
+        subtitle_state,
         updated_at
       )
       VALUES (
@@ -480,6 +563,7 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
           WHEN is_new_video THEN fn_video_collection_next_due_at(p_aid, p_bootstrap_priority, p_now)
           ELSE NULL
         END,
+        NULL,
         p_now
       )
       ON CONFLICT (aid) DO UPDATE SET
@@ -495,6 +579,7 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
         END,
         bootstrap_until = COALESCE(video_collection_state.bootstrap_until, EXCLUDED.bootstrap_until),
         next_minute_due_at = COALESCE(video_collection_state.next_minute_due_at, EXCLUDED.next_minute_due_at),
+        subtitle_state = video_collection_state.subtitle_state,
         updated_at = p_now;
 
       RETURN CASE WHEN is_new_video THEN 'upserted_bootstrap' ELSE 'upserted_backfill_daily_only' END;
@@ -832,6 +917,11 @@ export async function initCollectionStateSchema(pool: Pool): Promise<void> {
             ELSE fn_video_collection_next_due_at(s.aid, c.next_priority, c."time" + interval '1 second')
           END,
           next_gate_value = c.new_next_gate,
+          subtitle_state = fn_next_subtitle_state(
+            s.subtitle_state,
+            c.latest_view,
+            c.crossed_gate
+          ),
           updated_at = now()
       FROM computed c
       WHERE s.aid = c.aid;

--- a/src/database/schema/index.ts
+++ b/src/database/schema/index.ts
@@ -16,6 +16,7 @@ import { initVideoDailyLatestSchema } from "./video_daily_latest.js";
 import { initVideoHistorySchema } from "./video_history.js";
 import { initVideoMinuteSchema } from "./video_minute.js";
 import { initVideoStaticSchema } from "./video_static.js";
+import { initVideoSubtitlesSchema } from "./video_subtitles.js";
 import { initVideosSchema } from "./videos.js";
 
 export async function initializeSchema(
@@ -50,6 +51,8 @@ export async function initializeSchema(
     initCronVideoStatic(pool, schema),
     initCronUserStats(pool, schema),
   ]);
+
+  await initVideoSubtitlesSchema(pool);
 
   logger.info("Database schema initialized");
 }

--- a/src/database/schema/video_subtitles.ts
+++ b/src/database/schema/video_subtitles.ts
@@ -1,0 +1,65 @@
+import type { Pool } from "pg";
+import { logger } from "../../utils/logger.js";
+
+export async function initVideoSubtitlesSchema(pool: Pool): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS video_subtitles (
+      aid           bigint       NOT NULL,
+      cid           bigint       NOT NULL,
+      lan           varchar(20)  NOT NULL,
+      lan_doc       varchar(50),
+      subtitle_type smallint,
+      ai_type       smallint,
+      ai_status     smallint,
+      body          jsonb        NOT NULL,
+      plain_text    text,
+      line_count    integer,
+      style         jsonb,
+      fetched_at    timestamptz  NOT NULL DEFAULT now(),
+      updated_at    timestamptz  NOT NULL DEFAULT now(),
+      PRIMARY KEY (aid, cid, lan)
+    )
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_video_subtitles_aid
+    ON video_subtitles(aid)
+  `);
+
+  await pool.query(`
+    CREATE OR REPLACE FUNCTION fn_subtitle_on_gate_crossing()
+    RETURNS trigger AS $$
+    BEGIN
+      UPDATE video_collection_state
+      SET subtitle_state = fn_next_subtitle_state(
+            subtitle_state,
+            greatest(COALESCE(last_view, 0), COALESCE(NEW.current_view, 0)),
+            NEW.gate_value
+          ),
+          updated_at = now()
+      WHERE aid = NEW.aid
+        AND subtitle_state IS DISTINCT FROM fn_next_subtitle_state(
+          subtitle_state,
+          greatest(COALESCE(last_view, 0), COALESCE(NEW.current_view, 0)),
+          NEW.gate_value
+        );
+
+      RETURN NULL;
+    END;
+    $$ LANGUAGE plpgsql
+  `);
+
+  await pool.query(`
+    DROP TRIGGER IF EXISTS trg_subtitle_on_gate_crossing
+    ON video_collection_gate_crossings
+  `);
+
+  await pool.query(`
+    CREATE TRIGGER trg_subtitle_on_gate_crossing
+      AFTER INSERT ON video_collection_gate_crossings
+      FOR EACH ROW
+      EXECUTE FUNCTION fn_subtitle_on_gate_crossing()
+  `);
+
+  logger.info("video_subtitles: schema ready");
+}

--- a/src/database/subtitles.ts
+++ b/src/database/subtitles.ts
@@ -224,7 +224,8 @@ export async function getSubtitleStateCounts(
     `SELECT CASE
               WHEN subtitle_state IS NULL THEN 'not_eligible'
               WHEN subtitle_state IN (
-                'pending', 'has_manual', 'ai_only', 'no_subtitle', 'skipped'
+                'pending', 'has_manual', 'partial_manual', 'ai_only',
+                'no_subtitle', 'skipped'
               ) THEN subtitle_state
               ELSE 'unknown'
             END AS state,

--- a/src/database/subtitles.ts
+++ b/src/database/subtitles.ts
@@ -27,6 +27,13 @@ export interface UpsertSubtitleInput {
   style: BiliSubtitleStyle | null;
 }
 
+export interface UpsertSubtitleResult {
+  affectedCount: number;
+  insertedCount: number;
+  insertedManualCount: number;
+  insertedAiCount: number;
+}
+
 function mapSubtitleRow(row: Record<string, unknown>): VideoSubtitleRow {
   return {
     aid: BigInt(row.aid as string | number),
@@ -62,36 +69,70 @@ function subtitleInputParams(input: UpsertSubtitleInput): unknown[] {
 }
 
 const UPSERT_SUBTITLE_SQL = `
-  INSERT INTO video_subtitles (
-    aid, cid, lan, lan_doc, subtitle_type, ai_type, ai_status,
-    body, plain_text, line_count, style, fetched_at, updated_at
-  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now(), now())
-  ON CONFLICT (aid, cid, lan) DO UPDATE SET
-    lan_doc       = EXCLUDED.lan_doc,
-    subtitle_type = EXCLUDED.subtitle_type,
-    ai_type       = EXCLUDED.ai_type,
-    ai_status     = EXCLUDED.ai_status,
-    body          = EXCLUDED.body,
-    plain_text    = EXCLUDED.plain_text,
-    line_count    = EXCLUDED.line_count,
-    style         = EXCLUDED.style,
-    updated_at    = now()
+  WITH inserted AS (
+    INSERT INTO video_subtitles (
+      aid, cid, lan, lan_doc, subtitle_type, ai_type, ai_status,
+      body, plain_text, line_count, style, fetched_at, updated_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now(), now())
+    ON CONFLICT (aid, cid, lan) DO NOTHING
+    RETURNING true AS inserted
+  ),
+  updated AS (
+    UPDATE video_subtitles
+    SET lan_doc       = $4,
+        subtitle_type = $5,
+        ai_type       = $6,
+        ai_status     = $7,
+        body          = $8,
+        plain_text    = $9,
+        line_count    = $10,
+        style         = $11,
+        updated_at    = now()
+    WHERE aid = $1
+      AND cid = $2
+      AND lan = $3
+      AND NOT EXISTS (SELECT 1 FROM inserted)
+    RETURNING false AS inserted
+  )
+  SELECT inserted FROM inserted
+  UNION ALL
+  SELECT inserted FROM updated
 `;
 
 export async function upsertSubtitlesBatch(
   pool: Pool,
   inputs: UpsertSubtitleInput[],
-): Promise<number> {
-  if (inputs.length === 0) return 0;
+): Promise<UpsertSubtitleResult> {
+  const result: UpsertSubtitleResult = {
+    affectedCount: 0,
+    insertedCount: 0,
+    insertedManualCount: 0,
+    insertedAiCount: 0,
+  };
+  if (inputs.length === 0) return result;
 
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
     for (const input of inputs) {
-      await client.query(UPSERT_SUBTITLE_SQL, subtitleInputParams(input));
+      const queryResult = await client.query<{ inserted: boolean }>(
+        UPSERT_SUBTITLE_SQL,
+        subtitleInputParams(input),
+      );
+      if (queryResult.rows.length > 0) {
+        result.affectedCount += queryResult.rows.length;
+      }
+      if (queryResult.rows[0]?.inserted === true) {
+        result.insertedCount += 1;
+        if (input.aiType === 0) {
+          result.insertedManualCount += 1;
+        } else if (input.aiType !== null && input.aiType > 0) {
+          result.insertedAiCount += 1;
+        }
+      }
     }
     await client.query("COMMIT");
-    return inputs.length;
+    return result;
   } catch (error) {
     await client.query("ROLLBACK");
     throw error;

--- a/src/database/subtitles.ts
+++ b/src/database/subtitles.ts
@@ -1,0 +1,235 @@
+import type { Pool } from "pg";
+import type {
+  BiliSubtitleLine,
+  BiliSubtitleStyle,
+  SubtitleState,
+  VideoSubtitleRow,
+} from "../types/bilibili/subtitle.js";
+
+export interface SubtitleJob {
+  aid: bigint;
+  bvid: string | null;
+  lastView: bigint | null;
+  isDeleted: boolean;
+}
+
+export interface UpsertSubtitleInput {
+  aid: bigint;
+  cid: bigint;
+  lan: string;
+  lanDoc: string | null;
+  subtitleType: number | null;
+  aiType: number | null;
+  aiStatus: number | null;
+  body: BiliSubtitleLine[];
+  style: BiliSubtitleStyle | null;
+}
+
+function mapSubtitleRow(row: Record<string, unknown>): VideoSubtitleRow {
+  return {
+    aid: BigInt(row.aid as string | number),
+    cid: BigInt(row.cid as string | number),
+    lan: row.lan as string,
+    lanDoc: (row.lan_doc as string | null) ?? null,
+    subtitleType: (row.subtitle_type as number | null) ?? null,
+    aiType: (row.ai_type as number | null) ?? null,
+    aiStatus: (row.ai_status as number | null) ?? null,
+    body: row.body as BiliSubtitleLine[],
+    plainText: (row.plain_text as string | null) ?? null,
+    lineCount: (row.line_count as number | null) ?? null,
+    style: (row.style as BiliSubtitleStyle | null) ?? null,
+    fetchedAt: new Date(row.fetched_at as string | Date),
+    updatedAt: new Date(row.updated_at as string | Date),
+  };
+}
+
+function subtitleInputParams(input: UpsertSubtitleInput): unknown[] {
+  return [
+    input.aid.toString(),
+    input.cid.toString(),
+    input.lan,
+    input.lanDoc,
+    input.subtitleType,
+    input.aiType,
+    input.aiStatus,
+    JSON.stringify(input.body),
+    input.body.map((line) => line.content).join("\n"),
+    input.body.length,
+    input.style ? JSON.stringify(input.style) : null,
+  ];
+}
+
+const UPSERT_SUBTITLE_SQL = `
+  INSERT INTO video_subtitles (
+    aid, cid, lan, lan_doc, subtitle_type, ai_type, ai_status,
+    body, plain_text, line_count, style, fetched_at, updated_at
+  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now(), now())
+  ON CONFLICT (aid, cid, lan) DO UPDATE SET
+    lan_doc       = EXCLUDED.lan_doc,
+    subtitle_type = EXCLUDED.subtitle_type,
+    ai_type       = EXCLUDED.ai_type,
+    ai_status     = EXCLUDED.ai_status,
+    body          = EXCLUDED.body,
+    plain_text    = EXCLUDED.plain_text,
+    line_count    = EXCLUDED.line_count,
+    style         = EXCLUDED.style,
+    updated_at    = now()
+`;
+
+export async function upsertSubtitlesBatch(
+  pool: Pool,
+  inputs: UpsertSubtitleInput[],
+): Promise<number> {
+  if (inputs.length === 0) return 0;
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    for (const input of inputs) {
+      await client.query(UPSERT_SUBTITLE_SQL, subtitleInputParams(input));
+    }
+    await client.query("COMMIT");
+    return inputs.length;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function updateSubtitleState(
+  pool: Pool,
+  aid: bigint,
+  state: SubtitleState,
+): Promise<void> {
+  await pool.query(
+    `UPDATE video_collection_state
+     SET subtitle_state = $1,
+         subtitle_failure_count = 0,
+         last_subtitle_error_at = NULL,
+         subtitle_last_error = NULL,
+         updated_at = now()
+     WHERE aid = $2`,
+    [state, aid.toString()],
+  );
+}
+
+export async function recordSubtitleFailure(
+  pool: Pool,
+  aid: bigint,
+  errorMessage: string,
+  maxRetries: number,
+): Promise<{ state: SubtitleState | null; failureCount: number }> {
+  const result = await pool.query<{
+    subtitle_state: SubtitleState | null;
+    subtitle_failure_count: number;
+  }>(
+    `UPDATE video_collection_state
+     SET subtitle_failure_count = subtitle_failure_count + 1,
+         last_subtitle_error_at = now(),
+         subtitle_last_error = left($2, 500),
+         subtitle_state = CASE
+           WHEN subtitle_failure_count + 1 >= $3 THEN 'skipped'
+           ELSE subtitle_state
+         END,
+         updated_at = now()
+     WHERE aid = $1
+     RETURNING subtitle_state, subtitle_failure_count`,
+    [aid.toString(), errorMessage, maxRetries],
+  );
+
+  const row = result.rows[0];
+  return {
+    state: row?.subtitle_state ?? null,
+    failureCount: Number(row?.subtitle_failure_count ?? 0),
+  };
+}
+
+export async function selectNextSubtitleJob(
+  pool: Pool,
+): Promise<SubtitleJob | null> {
+  const result = await pool.query<{
+    aid: string;
+    bvid: string | null;
+    last_view: string | null;
+    is_deleted: boolean | null;
+  }>(
+    `SELECT s.aid, p.bvid, s.last_view, p.is_deleted
+     FROM video_collection_state s
+     LEFT JOIN processed_videos p ON p.aid = s.aid
+     WHERE s.subtitle_state = 'pending'
+     ORDER BY s.last_view DESC NULLS LAST, s.aid ASC
+     LIMIT 1`,
+  );
+
+  const row = result.rows[0];
+  if (!row) return null;
+
+  return {
+    aid: BigInt(row.aid),
+    bvid: row.bvid,
+    lastView: row.last_view === null ? null : BigInt(row.last_view),
+    isDeleted: row.is_deleted === true,
+  };
+}
+
+export async function getSubtitlesByAid(
+  pool: Pool,
+  aid: bigint,
+): Promise<VideoSubtitleRow[]> {
+  const result = await pool.query(
+    `SELECT *
+     FROM video_subtitles
+     WHERE aid = $1
+     ORDER BY cid ASC, lan ASC`,
+    [aid.toString()],
+  );
+  return result.rows.map(mapSubtitleRow);
+}
+
+export async function getSubtitlesByCid(
+  pool: Pool,
+  aid: bigint,
+  cid: bigint,
+): Promise<VideoSubtitleRow[]> {
+  const result = await pool.query(
+    `SELECT *
+     FROM video_subtitles
+     WHERE aid = $1 AND cid = $2
+     ORDER BY lan ASC`,
+    [aid.toString(), cid.toString()],
+  );
+  return result.rows.map(mapSubtitleRow);
+}
+
+export async function cidHasManualSubtitle(
+  pool: Pool,
+  aid: bigint,
+  cid: bigint,
+): Promise<boolean> {
+  const result = await pool.query<{ found: boolean }>(
+    `SELECT EXISTS(
+       SELECT 1
+       FROM video_subtitles
+       WHERE aid = $1 AND cid = $2 AND ai_type = 0
+     ) AS found`,
+    [aid.toString(), cid.toString()],
+  );
+  return result.rows[0]?.found === true;
+}
+
+export async function aidHasManualSubtitle(
+  pool: Pool,
+  aid: bigint,
+): Promise<boolean> {
+  const result = await pool.query<{ found: boolean }>(
+    `SELECT EXISTS(
+       SELECT 1
+       FROM video_subtitles
+       WHERE aid = $1 AND ai_type = 0
+     ) AS found`,
+    [aid.toString()],
+  );
+  return result.rows[0]?.found === true;
+}

--- a/src/database/subtitles.ts
+++ b/src/database/subtitles.ts
@@ -286,17 +286,18 @@ export async function cidHasManualSubtitle(
   return result.rows[0]?.found === true;
 }
 
-export async function aidHasManualSubtitle(
+export async function cidHasAiSubtitle(
   pool: Pool,
   aid: bigint,
+  cid: bigint,
 ): Promise<boolean> {
   const result = await pool.query<{ found: boolean }>(
     `SELECT EXISTS(
        SELECT 1
        FROM video_subtitles
-       WHERE aid = $1 AND ai_type = 0
+       WHERE aid = $1 AND cid = $2 AND ai_type > 0
      ) AS found`,
-    [aid.toString()],
+    [aid.toString(), cid.toString()],
   );
   return result.rows[0]?.found === true;
 }

--- a/src/database/subtitles.ts
+++ b/src/database/subtitles.ts
@@ -13,6 +13,8 @@ export interface SubtitleJob {
   isDeleted: boolean;
 }
 
+export type SubtitleStateMetric = SubtitleState | "not_eligible" | "unknown";
+
 export interface UpsertSubtitleInput {
   aid: bigint;
   cid: bigint;
@@ -172,6 +174,30 @@ export async function selectNextSubtitleJob(
     lastView: row.last_view === null ? null : BigInt(row.last_view),
     isDeleted: row.is_deleted === true,
   };
+}
+
+export async function getSubtitleStateCounts(
+  pool: Pool,
+): Promise<Partial<Record<SubtitleStateMetric, number>>> {
+  const result = await pool.query<{ state: string; count: string }>(
+    `SELECT CASE
+              WHEN subtitle_state IS NULL THEN 'not_eligible'
+              WHEN subtitle_state IN (
+                'pending', 'has_manual', 'ai_only', 'no_subtitle', 'skipped'
+              ) THEN subtitle_state
+              ELSE 'unknown'
+            END AS state,
+            count(*)::text AS count
+     FROM video_collection_state
+     GROUP BY state`,
+  );
+
+  const counts: Partial<Record<SubtitleStateMetric, number>> = {};
+  for (const row of result.rows) {
+    const state = row.state as SubtitleStateMetric;
+    counts[state] = (counts[state] ?? 0) + Number(row.count);
+  }
+  return counts;
 }
 
 export async function getSubtitlesByAid(

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Database } from "./database";
 import { initializeBuildInfo } from "./metrics/registry";
 import { startMetricsServer, stopMetricsServer } from "./metrics/server";
 import { MinuteHandler } from "./services/minute/minuteHandler";
+import { SubtitleService } from "./services/subtitle.service";
 import { DynamicTracker } from "./services/tracker";
 import { logger } from "./utils/logger";
 import { APP_VERSION } from "./version";
@@ -25,7 +26,12 @@ async function runTracker() {
 
   const trackers = accounts.map((account) => new DynamicTracker(account));
   const minuteHandler = config.minute.enabled ? new MinuteHandler() : null;
+  const subtitleService =
+    config.subtitle.enabled && accounts.length > 0
+      ? new SubtitleService(accounts[0])
+      : null;
   minuteHandler?.start();
+  subtitleService?.start();
 
   // Graceful shutdown
   const shutdown = async () => {
@@ -34,6 +40,7 @@ async function runTracker() {
       tracker.stop();
     }
     if (minuteHandler) await minuteHandler.stop();
+    if (subtitleService) await subtitleService.stop();
     await stopMetricsServer();
     try {
       await Database.getInstance().close();

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -153,6 +153,45 @@ export const subtitleJobsTotal = new Counter({
   registers: [metricsRegistry],
 });
 
+export const subtitleTicksTotal = new Counter({
+  name: `${PREFIX}subtitle_ticks_total`,
+  help: "Total subtitle service ticks by outcome.",
+  labelNames: ["outcome"] as const,
+  registers: [metricsRegistry],
+});
+
+export const subtitleServiceRunning = new Gauge({
+  name: `${PREFIX}subtitle_service_running`,
+  help: "Whether the subtitle service loop is running.",
+  labelNames: ["uid"] as const,
+  registers: [metricsRegistry],
+});
+
+export const subtitleActiveJobs = new Gauge({
+  name: `${PREFIX}subtitle_active_jobs`,
+  help: "Current subtitle jobs in progress.",
+  registers: [metricsRegistry],
+});
+
+export const subtitleStateRows = new Gauge({
+  name: `${PREFIX}subtitle_state_rows`,
+  help: "Current video_collection_state rows by subtitle_state.",
+  labelNames: ["state"] as const,
+  registers: [metricsRegistry],
+});
+
+export const subtitleLastTickTimestampSeconds = new Gauge({
+  name: `${PREFIX}subtitle_last_tick_timestamp_seconds`,
+  help: "Unix timestamp of the last subtitle service tick.",
+  registers: [metricsRegistry],
+});
+
+export const subtitleLastCompletedJobTimestampSeconds = new Gauge({
+  name: `${PREFIX}subtitle_last_completed_job_timestamp_seconds`,
+  help: "Unix timestamp of the last completed subtitle job.",
+  registers: [metricsRegistry],
+});
+
 export const subtitleTracksTotal = new Counter({
   name: `${PREFIX}subtitle_tracks_total`,
   help: "Total subtitle tracks stored by kind.",
@@ -164,6 +203,21 @@ export const subtitleJobDurationSeconds = new Histogram({
   name: `${PREFIX}subtitle_job_duration_seconds`,
   help: "Subtitle collection job duration in seconds.",
   buckets: [0.5, 1, 2, 5, 10, 30, 60, 120],
+  registers: [metricsRegistry],
+});
+
+export const subtitleApiRequestsTotal = new Counter({
+  name: `${PREFIX}subtitle_api_requests_total`,
+  help: "Total subtitle API requests by endpoint and result.",
+  labelNames: ["endpoint", "result"] as const,
+  registers: [metricsRegistry],
+});
+
+export const subtitleApiRequestDurationSeconds = new Histogram({
+  name: `${PREFIX}subtitle_api_request_duration_seconds`,
+  help: "Subtitle API request duration in seconds.",
+  labelNames: ["endpoint"] as const,
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
   registers: [metricsRegistry],
 });
 

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -146,6 +146,27 @@ export const minuteBatchDurationSeconds = new Histogram({
   registers: [metricsRegistry],
 });
 
+export const subtitleJobsTotal = new Counter({
+  name: `${PREFIX}subtitle_jobs_total`,
+  help: "Total subtitle collection jobs by outcome.",
+  labelNames: ["outcome"] as const,
+  registers: [metricsRegistry],
+});
+
+export const subtitleTracksTotal = new Counter({
+  name: `${PREFIX}subtitle_tracks_total`,
+  help: "Total subtitle tracks stored by kind.",
+  labelNames: ["kind"] as const,
+  registers: [metricsRegistry],
+});
+
+export const subtitleJobDurationSeconds = new Histogram({
+  name: `${PREFIX}subtitle_job_duration_seconds`,
+  help: "Subtitle collection job duration in seconds.",
+  buckets: [0.5, 1, 2, 5, 10, 30, 60, 120],
+  registers: [metricsRegistry],
+});
+
 export const notificationsTotal = new Counter({
   name: `${PREFIX}notifications_total`,
   help: "Total notification attempts by channel and result.",

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -186,9 +186,9 @@ export const subtitleLastTickTimestampSeconds = new Gauge({
   registers: [metricsRegistry],
 });
 
-export const subtitleLastCompletedJobTimestampSeconds = new Gauge({
-  name: `${PREFIX}subtitle_last_completed_job_timestamp_seconds`,
-  help: "Unix timestamp of the last completed subtitle job.",
+export const subtitleLastTerminalJobTimestampSeconds = new Gauge({
+  name: `${PREFIX}subtitle_last_terminal_job_timestamp_seconds`,
+  help: "Unix timestamp of the last subtitle job that reached a terminal state.",
   registers: [metricsRegistry],
 });
 

--- a/src/services/subtitle.service.ts
+++ b/src/services/subtitle.service.ts
@@ -29,6 +29,7 @@ const SUBTITLE_STATE_METRIC_LABELS = [
   "not_eligible",
   "pending",
   "has_manual",
+  "partial_manual",
   "ai_only",
   "no_subtitle",
   "skipped",
@@ -39,6 +40,7 @@ type SubtitleTickOutcome =
   | "no_job"
   | "skipped"
   | "has_manual"
+  | "partial_manual"
   | "ai_only"
   | "no_subtitle"
   | "failed"
@@ -174,6 +176,7 @@ export class SubtitleService {
 
       const bvid = view.bvid || job.bvid;
       let allPagesHaveManual = view.pages.length > 0;
+      let anyManual = false;
       let anyAi = false;
       const subtitles: UpsertSubtitleInput[] = [];
 
@@ -182,6 +185,7 @@ export class SubtitleService {
           job.aid,
           page.cid,
         );
+        anyManual = anyManual || pageHasManual;
         anyAi = anyAi || (await this.db.cidHasAiSubtitle(job.aid, page.cid));
         if (pageHasManual) {
           continue;
@@ -196,7 +200,10 @@ export class SubtitleService {
           if (!track.subtitle_url) continue;
 
           const subtitleJson = await fetchSubtitleJson(track.subtitle_url);
-          if (isManualSubtitle(track)) pageHasManual = true;
+          if (isManualSubtitle(track)) {
+            pageHasManual = true;
+            anyManual = true;
+          }
           if (isAiSubtitle(track)) anyAi = true;
 
           subtitles.push({
@@ -226,9 +233,11 @@ export class SubtitleService {
 
       const nextState = allPagesHaveManual
         ? "has_manual"
-        : anyAi
-          ? "ai_only"
-          : "no_subtitle";
+        : anyManual
+          ? "partial_manual"
+          : anyAi
+            ? "ai_only"
+            : "no_subtitle";
       await this.db.updateSubtitleState(job.aid, nextState);
       subtitleJobsTotal.inc({ outcome: nextState });
       subtitleLastTerminalJobTimestampSeconds.set(Date.now() / 1000);

--- a/src/services/subtitle.service.ts
+++ b/src/services/subtitle.service.ts
@@ -1,0 +1,197 @@
+import {
+  fetchPlayerSubtitleTracks,
+  fetchSubtitleJson,
+  fetchSubtitleVideoView,
+} from "../api/subtitle.js";
+import { config } from "../config";
+import type { AccountContext } from "../core/account";
+import { Database } from "../database";
+import type { UpsertSubtitleInput } from "../database/subtitles.js";
+import {
+  subtitleJobDurationSeconds,
+  subtitleJobsTotal,
+  subtitleTracksTotal,
+} from "../metrics/registry";
+import {
+  type BiliSubtitleStyle,
+  isAiSubtitle,
+  isManualSubtitle,
+} from "../types/bilibili/subtitle.js";
+import { logger } from "../utils/logger";
+
+function cancellableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) return resolve();
+    const timer = setTimeout(onDone, ms);
+
+    function onDone() {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onDone);
+      resolve();
+    }
+
+    signal.addEventListener("abort", onDone, { once: true });
+    if (signal.aborted) onDone();
+  });
+}
+
+function getSubtitleStyle(json: BiliSubtitleStyle): BiliSubtitleStyle {
+  return {
+    font_size: json.font_size,
+    font_color: json.font_color,
+    background_alpha: json.background_alpha,
+    background_color: json.background_color,
+    Stroke: json.Stroke,
+  };
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class SubtitleService {
+  private readonly db = Database.getInstance();
+  private readonly account: AccountContext;
+  private isRunning = false;
+  private loopPromise: Promise<void> | null = null;
+  private abortController: AbortController | null = null;
+
+  constructor(account: AccountContext) {
+    this.account = account;
+  }
+
+  start(): void {
+    if (this.loopPromise) return;
+    this.isRunning = true;
+    this.abortController = new AbortController();
+    this.loopPromise = this.loop(this.abortController.signal);
+    logger.info(
+      `Subtitle service started (interval=${config.subtitle.fetchIntervalMs}ms, uid=${this.account.uid || "unknown"})`,
+    );
+  }
+
+  async stop(): Promise<void> {
+    this.isRunning = false;
+    this.abortController?.abort();
+    logger.info("Subtitle service stopping");
+    if (this.loopPromise) {
+      await this.loopPromise;
+    }
+    this.abortController = null;
+    logger.info("Subtitle service stopped");
+  }
+
+  private async loop(signal: AbortSignal): Promise<void> {
+    while (this.isRunning) {
+      try {
+        await this.processOne();
+      } catch (error) {
+        logger.error("Subtitle service loop error:", error);
+      }
+
+      await cancellableSleep(config.subtitle.fetchIntervalMs, signal);
+    }
+
+    this.loopPromise = null;
+  }
+
+  private async processOne(): Promise<void> {
+    const job = await this.db.selectNextSubtitleJob();
+    if (!job) return;
+
+    const endJob = subtitleJobDurationSeconds.startTimer();
+    try {
+      if (job.isDeleted || !job.bvid) {
+        await this.db.updateSubtitleState(job.aid, "skipped");
+        subtitleJobsTotal.inc({ outcome: "skipped" });
+        return;
+      }
+
+      logger.info(
+        `Fetching subtitles for aid=${job.aid} bvid=${job.bvid} view=${job.lastView?.toString() ?? "unknown"}`,
+      );
+
+      const view = await fetchSubtitleVideoView(
+        this.account.webInterfaceClient,
+        job.aid,
+      );
+      if (!view) {
+        await this.db.updateSubtitleState(job.aid, "skipped");
+        subtitleJobsTotal.inc({ outcome: "skipped" });
+        return;
+      }
+
+      const bvid = view.bvid || job.bvid;
+      let anyManual = await this.db.aidHasManualSubtitle(job.aid);
+      let anyAi = false;
+      const subtitles: UpsertSubtitleInput[] = [];
+
+      for (const page of view.pages) {
+        if (await this.db.cidHasManualSubtitle(job.aid, page.cid)) {
+          anyManual = true;
+          continue;
+        }
+
+        const tracks = await fetchPlayerSubtitleTracks(
+          this.account.playerClient,
+          bvid,
+          page.cid,
+        );
+        if (tracks.length === 0) continue;
+
+        for (const track of tracks) {
+          if (!track.subtitle_url) continue;
+
+          const subtitleJson = await fetchSubtitleJson(track.subtitle_url);
+          if (isManualSubtitle(track)) anyManual = true;
+          if (isAiSubtitle(track)) anyAi = true;
+
+          subtitles.push({
+            aid: job.aid,
+            cid: page.cid,
+            lan: track.lan,
+            lanDoc: track.lan_doc || null,
+            subtitleType: track.type,
+            aiType: track.ai_type,
+            aiStatus: track.ai_status,
+            body: subtitleJson.body,
+            style: getSubtitleStyle(subtitleJson),
+          });
+        }
+      }
+
+      const storedCount = await this.db.upsertSubtitlesBatch(subtitles);
+      if (storedCount > 0) {
+        subtitleTracksTotal.inc({ kind: "total" }, storedCount);
+        subtitleTracksTotal.inc(
+          { kind: "manual" },
+          subtitles.filter((item) => item.aiType === 0).length,
+        );
+        subtitleTracksTotal.inc(
+          { kind: "ai" },
+          subtitles.filter((item) => item.aiType !== null && item.aiType > 0)
+            .length,
+        );
+      }
+
+      const nextState = anyManual
+        ? "has_manual"
+        : anyAi
+          ? "ai_only"
+          : "no_subtitle";
+      await this.db.updateSubtitleState(job.aid, nextState);
+      subtitleJobsTotal.inc({ outcome: nextState });
+    } catch (error) {
+      const message = getErrorMessage(error);
+      const failure = await this.db.recordSubtitleFailure(job.aid, message);
+      subtitleJobsTotal.inc({
+        outcome: failure.state === "skipped" ? "skipped_after_retry" : "failed",
+      });
+      logger.error(
+        `Subtitle job failed for aid=${job.aid} failure_count=${failure.failureCount}: ${message}`,
+      );
+    } finally {
+      endJob();
+    }
+  }
+}

--- a/src/services/subtitle.service.ts
+++ b/src/services/subtitle.service.ts
@@ -35,6 +35,15 @@ const SUBTITLE_STATE_METRIC_LABELS = [
   "unknown",
 ] as const;
 
+type SubtitleTickOutcome =
+  | "no_job"
+  | "skipped"
+  | "has_manual"
+  | "ai_only"
+  | "no_subtitle"
+  | "failed"
+  | "skipped_after_retry";
+
 function cancellableSleep(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
     if (signal.aborted) return resolve();
@@ -128,7 +137,7 @@ export class SubtitleService {
     }
   }
 
-  private async processOne(): Promise<string> {
+  private async processOne(): Promise<SubtitleTickOutcome> {
     await this.sampleStateMetrics();
     const job = await this.db.selectNextSubtitleJob();
     if (!job) return "no_job";

--- a/src/services/subtitle.service.ts
+++ b/src/services/subtitle.service.ts
@@ -8,8 +8,14 @@ import type { AccountContext } from "../core/account";
 import { Database } from "../database";
 import type { UpsertSubtitleInput } from "../database/subtitles.js";
 import {
+  subtitleActiveJobs,
   subtitleJobDurationSeconds,
   subtitleJobsTotal,
+  subtitleLastCompletedJobTimestampSeconds,
+  subtitleLastTickTimestampSeconds,
+  subtitleServiceRunning,
+  subtitleStateRows,
+  subtitleTicksTotal,
   subtitleTracksTotal,
 } from "../metrics/registry";
 import {
@@ -18,6 +24,16 @@ import {
   isManualSubtitle,
 } from "../types/bilibili/subtitle.js";
 import { logger } from "../utils/logger";
+
+const SUBTITLE_STATE_METRIC_LABELS = [
+  "not_eligible",
+  "pending",
+  "has_manual",
+  "ai_only",
+  "no_subtitle",
+  "skipped",
+  "unknown",
+] as const;
 
 function cancellableSleep(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
@@ -64,6 +80,7 @@ export class SubtitleService {
     if (this.loopPromise) return;
     this.isRunning = true;
     this.abortController = new AbortController();
+    subtitleServiceRunning.set({ uid: this.account.uid || "unknown" }, 1);
     this.loopPromise = this.loop(this.abortController.signal);
     logger.info(
       `Subtitle service started (interval=${config.subtitle.fetchIntervalMs}ms, uid=${this.account.uid || "unknown"})`,
@@ -73,6 +90,8 @@ export class SubtitleService {
   async stop(): Promise<void> {
     this.isRunning = false;
     this.abortController?.abort();
+    subtitleServiceRunning.set({ uid: this.account.uid || "unknown" }, 0);
+    subtitleActiveJobs.set(0);
     logger.info("Subtitle service stopping");
     if (this.loopPromise) {
       await this.loopPromise;
@@ -84,8 +103,11 @@ export class SubtitleService {
   private async loop(signal: AbortSignal): Promise<void> {
     while (this.isRunning) {
       try {
-        await this.processOne();
+        subtitleLastTickTimestampSeconds.set(Date.now() / 1000);
+        const outcome = await this.processOne();
+        subtitleTicksTotal.inc({ outcome });
       } catch (error) {
+        subtitleTicksTotal.inc({ outcome: "error" });
         logger.error("Subtitle service loop error:", error);
       }
 
@@ -95,16 +117,30 @@ export class SubtitleService {
     this.loopPromise = null;
   }
 
-  private async processOne(): Promise<void> {
+  private async sampleStateMetrics(): Promise<void> {
+    try {
+      const counts = await this.db.getSubtitleStateCounts();
+      for (const state of SUBTITLE_STATE_METRIC_LABELS) {
+        subtitleStateRows.set({ state }, counts[state] ?? 0);
+      }
+    } catch (error) {
+      logger.warn("Failed to sample subtitle state metrics:", error);
+    }
+  }
+
+  private async processOne(): Promise<string> {
+    await this.sampleStateMetrics();
     const job = await this.db.selectNextSubtitleJob();
-    if (!job) return;
+    if (!job) return "no_job";
 
     const endJob = subtitleJobDurationSeconds.startTimer();
+    subtitleActiveJobs.set(1);
     try {
       if (job.isDeleted || !job.bvid) {
         await this.db.updateSubtitleState(job.aid, "skipped");
         subtitleJobsTotal.inc({ outcome: "skipped" });
-        return;
+        subtitleLastCompletedJobTimestampSeconds.set(Date.now() / 1000);
+        return "skipped";
       }
 
       logger.info(
@@ -118,7 +154,8 @@ export class SubtitleService {
       if (!view) {
         await this.db.updateSubtitleState(job.aid, "skipped");
         subtitleJobsTotal.inc({ outcome: "skipped" });
-        return;
+        subtitleLastCompletedJobTimestampSeconds.set(Date.now() / 1000);
+        return "skipped";
       }
 
       const bvid = view.bvid || job.bvid;
@@ -181,16 +218,23 @@ export class SubtitleService {
           : "no_subtitle";
       await this.db.updateSubtitleState(job.aid, nextState);
       subtitleJobsTotal.inc({ outcome: nextState });
+      subtitleLastCompletedJobTimestampSeconds.set(Date.now() / 1000);
+      return nextState;
     } catch (error) {
       const message = getErrorMessage(error);
       const failure = await this.db.recordSubtitleFailure(job.aid, message);
-      subtitleJobsTotal.inc({
-        outcome: failure.state === "skipped" ? "skipped_after_retry" : "failed",
-      });
+      const outcome =
+        failure.state === "skipped" ? "skipped_after_retry" : "failed";
+      subtitleJobsTotal.inc({ outcome });
+      if (outcome === "skipped_after_retry") {
+        subtitleLastCompletedJobTimestampSeconds.set(Date.now() / 1000);
+      }
       logger.error(
         `Subtitle job failed for aid=${job.aid} failure_count=${failure.failureCount}: ${message}`,
       );
+      return outcome;
     } finally {
+      subtitleActiveJobs.set(0);
       endJob();
     }
   }

--- a/src/services/subtitle.service.ts
+++ b/src/services/subtitle.service.ts
@@ -42,7 +42,8 @@ type SubtitleTickOutcome =
   | "ai_only"
   | "no_subtitle"
   | "failed"
-  | "skipped_after_retry";
+  | "skipped_after_retry"
+  | "error";
 
 function cancellableSleep(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
@@ -114,9 +115,9 @@ export class SubtitleService {
       try {
         subtitleLastTickTimestampSeconds.set(Date.now() / 1000);
         const outcome = await this.processOne();
-        subtitleTicksTotal.inc({ outcome });
+        this.recordTick(outcome);
       } catch (error) {
-        subtitleTicksTotal.inc({ outcome: "error" });
+        this.recordTick("error");
         logger.error("Subtitle service loop error:", error);
       }
 
@@ -124,6 +125,10 @@ export class SubtitleService {
     }
 
     this.loopPromise = null;
+  }
+
+  private recordTick(outcome: SubtitleTickOutcome): void {
+    subtitleTicksTotal.inc({ outcome });
   }
 
   private async sampleStateMetrics(): Promise<void> {
@@ -206,18 +211,14 @@ export class SubtitleService {
         }
       }
 
-      const storedCount = await this.db.upsertSubtitlesBatch(subtitles);
-      if (storedCount > 0) {
-        subtitleTracksTotal.inc({ kind: "total" }, storedCount);
+      const storedResult = await this.db.upsertSubtitlesBatch(subtitles);
+      if (storedResult.insertedCount > 0) {
+        subtitleTracksTotal.inc({ kind: "total" }, storedResult.insertedCount);
         subtitleTracksTotal.inc(
           { kind: "manual" },
-          subtitles.filter((item) => item.aiType === 0).length,
+          storedResult.insertedManualCount,
         );
-        subtitleTracksTotal.inc(
-          { kind: "ai" },
-          subtitles.filter((item) => item.aiType !== null && item.aiType > 0)
-            .length,
-        );
+        subtitleTracksTotal.inc({ kind: "ai" }, storedResult.insertedAiCount);
       }
 
       const nextState = anyManual

--- a/src/services/subtitle.service.ts
+++ b/src/services/subtitle.service.ts
@@ -173,13 +173,17 @@ export class SubtitleService {
       }
 
       const bvid = view.bvid || job.bvid;
-      let anyManual = await this.db.aidHasManualSubtitle(job.aid);
+      let allPagesHaveManual = view.pages.length > 0;
       let anyAi = false;
       const subtitles: UpsertSubtitleInput[] = [];
 
       for (const page of view.pages) {
-        if (await this.db.cidHasManualSubtitle(job.aid, page.cid)) {
-          anyManual = true;
+        let pageHasManual = await this.db.cidHasManualSubtitle(
+          job.aid,
+          page.cid,
+        );
+        anyAi = anyAi || (await this.db.cidHasAiSubtitle(job.aid, page.cid));
+        if (pageHasManual) {
           continue;
         }
 
@@ -188,13 +192,11 @@ export class SubtitleService {
           bvid,
           page.cid,
         );
-        if (tracks.length === 0) continue;
-
         for (const track of tracks) {
           if (!track.subtitle_url) continue;
 
           const subtitleJson = await fetchSubtitleJson(track.subtitle_url);
-          if (isManualSubtitle(track)) anyManual = true;
+          if (isManualSubtitle(track)) pageHasManual = true;
           if (isAiSubtitle(track)) anyAi = true;
 
           subtitles.push({
@@ -209,6 +211,7 @@ export class SubtitleService {
             style: getSubtitleStyle(subtitleJson),
           });
         }
+        if (!pageHasManual) allPagesHaveManual = false;
       }
 
       const storedResult = await this.db.upsertSubtitlesBatch(subtitles);
@@ -221,7 +224,7 @@ export class SubtitleService {
         subtitleTracksTotal.inc({ kind: "ai" }, storedResult.insertedAiCount);
       }
 
-      const nextState = anyManual
+      const nextState = allPagesHaveManual
         ? "has_manual"
         : anyAi
           ? "ai_only"

--- a/src/services/subtitle.service.ts
+++ b/src/services/subtitle.service.ts
@@ -11,7 +11,7 @@ import {
   subtitleActiveJobs,
   subtitleJobDurationSeconds,
   subtitleJobsTotal,
-  subtitleLastCompletedJobTimestampSeconds,
+  subtitleLastTerminalJobTimestampSeconds,
   subtitleLastTickTimestampSeconds,
   subtitleServiceRunning,
   subtitleStateRows,
@@ -139,7 +139,7 @@ export class SubtitleService {
       if (job.isDeleted || !job.bvid) {
         await this.db.updateSubtitleState(job.aid, "skipped");
         subtitleJobsTotal.inc({ outcome: "skipped" });
-        subtitleLastCompletedJobTimestampSeconds.set(Date.now() / 1000);
+        subtitleLastTerminalJobTimestampSeconds.set(Date.now() / 1000);
         return "skipped";
       }
 
@@ -154,7 +154,7 @@ export class SubtitleService {
       if (!view) {
         await this.db.updateSubtitleState(job.aid, "skipped");
         subtitleJobsTotal.inc({ outcome: "skipped" });
-        subtitleLastCompletedJobTimestampSeconds.set(Date.now() / 1000);
+        subtitleLastTerminalJobTimestampSeconds.set(Date.now() / 1000);
         return "skipped";
       }
 
@@ -218,7 +218,7 @@ export class SubtitleService {
           : "no_subtitle";
       await this.db.updateSubtitleState(job.aid, nextState);
       subtitleJobsTotal.inc({ outcome: nextState });
-      subtitleLastCompletedJobTimestampSeconds.set(Date.now() / 1000);
+      subtitleLastTerminalJobTimestampSeconds.set(Date.now() / 1000);
       return nextState;
     } catch (error) {
       const message = getErrorMessage(error);
@@ -227,7 +227,7 @@ export class SubtitleService {
         failure.state === "skipped" ? "skipped_after_retry" : "failed";
       subtitleJobsTotal.inc({ outcome });
       if (outcome === "skipped_after_retry") {
-        subtitleLastCompletedJobTimestampSeconds.set(Date.now() / 1000);
+        subtitleLastTerminalJobTimestampSeconds.set(Date.now() / 1000);
       }
       logger.error(
         `Subtitle job failed for aid=${job.aid} failure_count=${failure.failureCount}: ${message}`,

--- a/src/types/bilibili/subtitle.ts
+++ b/src/types/bilibili/subtitle.ts
@@ -1,0 +1,74 @@
+export interface BiliSubtitleLine {
+  from: number;
+  to: number;
+  sid: number;
+  location: number;
+  content: string;
+}
+
+export interface BiliSubtitleStyle {
+  font_size?: number;
+  font_color?: string;
+  background_alpha?: number;
+  background_color?: string;
+  Stroke?: string;
+}
+
+export interface BiliSubtitleJson extends BiliSubtitleStyle {
+  body: BiliSubtitleLine[];
+}
+
+export interface BiliSubtitleTrackInfo {
+  id: number;
+  lan: string;
+  lan_doc: string;
+  subtitle_url: string;
+  type: number;
+  ai_type: number;
+  ai_status: number;
+}
+
+export interface BiliPlayerSubtitleResponse {
+  allow_submit: boolean;
+  subtitles: BiliSubtitleTrackInfo[];
+}
+
+export interface BiliPlayerWbiV2Response {
+  code: number;
+  message: string;
+  ttl: number;
+  data?: {
+    subtitle?: BiliPlayerSubtitleResponse;
+  };
+}
+
+export type SubtitleState =
+  | "pending"
+  | "has_manual"
+  | "ai_only"
+  | "no_subtitle"
+  | "skipped";
+
+export interface VideoSubtitleRow {
+  aid: bigint;
+  cid: bigint;
+  lan: string;
+  lanDoc: string | null;
+  subtitleType: number | null;
+  aiType: number | null;
+  aiStatus: number | null;
+  body: BiliSubtitleLine[];
+  plainText: string | null;
+  lineCount: number | null;
+  style: BiliSubtitleStyle | null;
+  fetchedAt: Date;
+  updatedAt: Date;
+}
+
+export function isManualSubtitle(track: BiliSubtitleTrackInfo): boolean {
+  return track.ai_type === 0;
+}
+
+export function isAiSubtitle(track: BiliSubtitleTrackInfo): boolean {
+  return track.ai_type > 0;
+}

--- a/src/types/bilibili/subtitle.ts
+++ b/src/types/bilibili/subtitle.ts
@@ -45,6 +45,7 @@ export interface BiliPlayerWbiV2Response {
 export type SubtitleState =
   | "pending"
   | "has_manual"
+  | "partial_manual"
   | "ai_only"
   | "no_subtitle"
   | "skipped";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,16 @@ export type {
 export type { BiliVideoDetailResponse, VideoTagResponse } from "./api/video";
 // Bilibili dynamic types
 export type { BiliDynamicCard } from "./bilibili/dynamic";
+export type {
+  BiliPlayerSubtitleResponse,
+  BiliPlayerWbiV2Response,
+  BiliSubtitleJson,
+  BiliSubtitleLine,
+  BiliSubtitleStyle,
+  BiliSubtitleTrackInfo,
+  SubtitleState,
+  VideoSubtitleRow,
+} from "./bilibili/subtitle";
 // Bilibili video types
 export type {
   BiliVideoFullDetailResponse,

--- a/src/utils/subtitleFormat.ts
+++ b/src/utils/subtitleFormat.ts
@@ -1,0 +1,53 @@
+import type { BiliSubtitleLine } from "../types/bilibili/subtitle.js";
+
+function formatSrtTime(seconds: number): string {
+  const totalMs = Math.round(seconds * 1000);
+  const hours = Math.floor(totalMs / 3_600_000);
+  const minutes = Math.floor((totalMs % 3_600_000) / 60_000);
+  const secs = Math.floor((totalMs % 60_000) / 1000);
+  const ms = totalMs % 1000;
+
+  return (
+    `${String(hours).padStart(2, "0")}:` +
+    `${String(minutes).padStart(2, "0")}:` +
+    `${String(secs).padStart(2, "0")},` +
+    `${String(ms).padStart(3, "0")}`
+  );
+}
+
+function formatLrcTime(seconds: number): string {
+  const totalCs = Math.round(seconds * 100);
+  const minutes = Math.floor(totalCs / 6000);
+  const secs = Math.floor((totalCs % 6000) / 100);
+  const cs = totalCs % 100;
+
+  return (
+    `[${String(minutes).padStart(2, "0")}:` +
+    `${String(secs).padStart(2, "0")}.` +
+    `${String(cs).padStart(2, "0")}]`
+  );
+}
+
+export function toSrt(body: BiliSubtitleLine[]): string {
+  if (body.length === 0) return "";
+
+  const entries = body
+    .map((line, index) => {
+      const from = formatSrtTime(line.from);
+      const to = formatSrtTime(line.to);
+      return `${index + 1}\n${from} --> ${to}\n${line.content}`;
+    })
+    .join("\n\n");
+
+  return `${entries}\n`;
+}
+
+export function toTxt(body: BiliSubtitleLine[]): string {
+  return body.map((line) => line.content).join("\n");
+}
+
+export function toLrc(body: BiliSubtitleLine[]): string {
+  return body
+    .map((line) => `${formatLrcTime(line.from)}${line.content}`)
+    .join("\n");
+}


### PR DESCRIPTION
## Summary

- add subtitle schema, state machine, and backfill migration for eligible videos
- add direct authenticated subtitle API clients and a single-consumer subtitle service
- expose subtitle config, metrics, DB facade methods, and export helpers for SRT/TXT/LRC

## Rollout

1. Deploy this code.
2. Run `pnpm start -- --init-schema` or the project equivalent for schema initialization.
3. Run `migrations/002_subtitle_tables.sql` to backfill existing eligible rows into `pending`.

## Verification

- `pnpm check`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`
