### PR TITLE
Split related video signal from expansion

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -99,8 +99,12 @@ max_retries = 3
 enable_tag_fetch = false       # Whether to fetch video tags
 enable_user_relation = false   # Toggle for user relation features
 enable_deduplication = true    # Enable AID-based deduplication (default: true)
-enable_recommendation = false  # Enable recommendation tracking (default: false)
-max_recommendation_depth = 1   # Max depth for recommendation recursion (default: 1)
+enable_related_quality_signal = true  # Store related-video recommendation edges as collection evidence (default: true)
+enable_related_expansion = false      # Recursively collect related videos after a source passes filters (default: false)
+max_related_expansion_depth = 1       # Max recursive related-video expansion depth (default: 1)
+# Backward-compatible aliases used only when the explicit related_* keys above are unset.
+enable_recommendation = false
+max_recommendation_depth = 1
 
 [processing.filtering]
 # Content filtering settings

--- a/src/config/schemas/processing.ts
+++ b/src/config/schemas/processing.ts
@@ -8,6 +8,9 @@ export const processingSchema = z.object({
     enableDeduplication: z.coerce.boolean().default(true),
     enableRecommendation: z.coerce.boolean().default(false),
     maxRecommendationDepth: z.coerce.number().default(1),
+    enableRelatedQualitySignal: z.coerce.boolean().default(true),
+    enableRelatedExpansion: z.coerce.boolean().default(false),
+    maxRelatedExpansionDepth: z.coerce.number().default(1),
   }),
   filtering: z.object({
     typeIdWhitelist: z.array(z.number()).default([]),
@@ -28,6 +31,15 @@ export function createProcessingConfig(
     // biome-ignore lint/suspicious/noExplicitAny: Config values from TOML/env are inherently untyped and validated by zod
   ) => any,
 ): ProcessingConfig {
+  const legacyEnableRecommendation = getConfigValue(
+    ["processing", "features", "enable_recommendation"],
+    "ENABLE_RECOMMENDATION",
+  );
+  const legacyMaxRecommendationDepth = getConfigValue(
+    ["processing", "features", "max_recommendation_depth"],
+    "MAX_RECOMMENDATION_DEPTH",
+  );
+
   return {
     features: {
       enableTagFetch: getConfigValue(
@@ -45,16 +57,27 @@ export function createProcessingConfig(
         "ENABLE_DEDUPLICATION",
         true,
       ),
-      enableRecommendation: getConfigValue(
-        ["processing", "features", "enable_recommendation"],
-        "ENABLE_RECOMMENDATION",
+      enableRecommendation: legacyEnableRecommendation ?? false,
+      maxRecommendationDepth: legacyMaxRecommendationDepth ?? 1,
+      enableRelatedQualitySignal: getConfigValue(
+        ["processing", "features", "enable_related_quality_signal"],
+        "ENABLE_RELATED_QUALITY_SIGNAL",
+        true,
+      ),
+      enableRelatedExpansion:
+        getConfigValue(
+          ["processing", "features", "enable_related_expansion"],
+          "ENABLE_RELATED_EXPANSION",
+        ) ??
+        legacyEnableRecommendation ??
         false,
-      ),
-      maxRecommendationDepth: getConfigValue(
-        ["processing", "features", "max_recommendation_depth"],
-        "MAX_RECOMMENDATION_DEPTH",
+      maxRelatedExpansionDepth:
+        getConfigValue(
+          ["processing", "features", "max_related_expansion_depth"],
+          "MAX_RELATED_EXPANSION_DEPTH",
+        ) ??
+        legacyMaxRecommendationDepth ??
         1,
-      ),
     },
     filtering: {
       typeIdWhitelist:

--- a/src/scripts/import-csv.ts
+++ b/src/scripts/import-csv.ts
@@ -116,6 +116,12 @@ export async function runImportCsv() {
   let successCount = 0;
   let skippedCount = skippedImmediately;
   let errorCount = 0;
+  const features = config.processing?.features;
+  const recordRelatedEdges = features?.enableRelatedQualitySignal ?? true;
+  const enableRelatedExpansion =
+    features?.enableRelatedExpansion ?? features?.enableRecommendation ?? false;
+  const maxRelatedExpansionDepth =
+    features?.maxRelatedExpansionDepth ?? features?.maxRecommendationDepth ?? 1;
 
   bar.start(rows.length, skippedImmediately, {
     success: 0,
@@ -142,7 +148,12 @@ export async function runImportCsv() {
       try {
         const { video, relatedVideos } = await detailsService.processVideoById(
           id,
-          { skipCacheCheck: true },
+          {
+            processRecommendations: recordRelatedEdges,
+            processRelated:
+              enableRelatedExpansion && maxRelatedExpansionDepth > 0,
+            skipCacheCheck: true,
+          },
         );
         if (video) {
           successCount++;
@@ -157,19 +168,15 @@ export async function runImportCsv() {
           if (video.bvid) processedBvids.add(video.bvid);
           const collectedVideos: VideoData[] = [video];
 
-          const enableRecommendation =
-            config.processing?.features?.enableRecommendation ?? false;
-          const maxDepth =
-            config.processing?.features?.maxRecommendationDepth ?? 1;
-
-          if (enableRecommendation) {
+          if (enableRelatedExpansion) {
             await processRelatedQueue(
               detailsService,
               queue,
               1,
-              maxDepth,
+              maxRelatedExpansionDepth,
               collectedVideos,
               processedBvids,
+              recordRelatedEdges,
             );
           }
 
@@ -220,8 +227,9 @@ async function processRelatedQueue(
   maxDepth: number,
   results: VideoData[],
   seenBvids: Set<string>,
+  processRecommendations: boolean,
 ) {
-  if (depth >= maxDepth || queue.length === 0) return;
+  if (depth > maxDepth || queue.length === 0) return;
 
   const nextQueue: BiliDynamicCard[] = [];
 
@@ -232,6 +240,8 @@ async function processRelatedQueue(
 
     try {
       const { video, relatedVideos } = await service.processVideoById(bvid, {
+        processRecommendations,
+        processRelated: depth < maxDepth,
         skipCacheCheck: true,
       });
       if (video) {
@@ -251,6 +261,7 @@ async function processRelatedQueue(
       maxDepth,
       results,
       seenBvids,
+      processRecommendations,
     );
   }
 }

--- a/src/scripts/import-csv.ts
+++ b/src/scripts/import-csv.ts
@@ -151,7 +151,7 @@ export async function runImportCsv() {
           {
             processRecommendations: recordRelatedEdges,
             processRelated:
-              enableRelatedExpansion && maxRelatedExpansionDepth > 0,
+              enableRelatedExpansion && maxRelatedExpansionDepth > 1,
             skipCacheCheck: true,
           },
         );
@@ -168,7 +168,7 @@ export async function runImportCsv() {
           if (video.bvid) processedBvids.add(video.bvid);
           const collectedVideos: VideoData[] = [video];
 
-          if (enableRelatedExpansion) {
+          if (enableRelatedExpansion && maxRelatedExpansionDepth > 1) {
             await processRelatedQueue(
               detailsService,
               queue,
@@ -229,7 +229,7 @@ async function processRelatedQueue(
   seenBvids: Set<string>,
   processRecommendations: boolean,
 ) {
-  if (depth > maxDepth || queue.length === 0) return;
+  if (depth >= maxDepth || queue.length === 0) return;
 
   const nextQueue: BiliDynamicCard[] = [];
 

--- a/src/services/details.service.ts
+++ b/src/services/details.service.ts
@@ -15,6 +15,11 @@ import { filterVideo } from "../utils/filter";
 import { logger } from "../utils/logger";
 import type { RateLimiter } from "../utils/rateLimiter";
 
+interface VideoProcessingOptions {
+  processRecommendations?: boolean;
+  processRelated?: boolean;
+}
+
 export class DetailsService {
   private rateLimiter: RateLimiter;
   private db: Database;
@@ -32,11 +37,13 @@ export class DetailsService {
    */
   async processVideo(
     dynamic: BiliDynamicCard,
-    processRelated = true,
+    options: boolean | VideoProcessingOptions = {},
   ): Promise<{
     video: VideoData | null;
     relatedVideos: BiliDynamicCard[];
   }> {
+    const processingOptions =
+      typeof options === "boolean" ? { processRelated: options } : options;
     let bvid = dynamic.desc.bvid;
     try {
       if (dynamic.desc.type === 1) {
@@ -49,7 +56,7 @@ export class DetailsService {
         }
       }
 
-      return await this.processVideoById(bvid, { processRelated });
+      return await this.processVideoById(bvid, processingOptions);
     } catch (error) {
       if (isAccountAuthError(error)) {
         throw error;
@@ -345,11 +352,10 @@ export class DetailsService {
     const filtered = await filterVideo(videoData);
 
     if (options.processRecommendations && relatedVideos.length > 0) {
-      const recommendations = relatedVideos.map((v, index) => ({
-        videoAid: v.aid,
-        recommendedByAid: videoData.aid,
-        order: index,
-      }));
+      const recommendations = this.buildRecommendationInputs(
+        videoData.aid,
+        relatedVideos,
+      );
       await this.db.trackRecommendationsBatch(recommendations);
     }
 
@@ -562,7 +568,7 @@ export class DetailsService {
               },
             },
             uid: video.owner.mid,
-            rid: video.tid,
+            rid: BigInt(video.aid),
             view: video.stat.view,
             repost: 0,
             comment: 0,
@@ -580,5 +586,27 @@ export class DetailsService {
           }),
         }) as unknown as BiliDynamicCard,
     );
+  }
+
+  private buildRecommendationInputs(
+    sourceAid: bigint,
+    relatedVideos: RecommendedVideo[],
+  ): Array<{ videoAid: number; recommendedByAid: bigint; order: number }> {
+    const seenAids = new Set<number>();
+
+    return relatedVideos.flatMap((video, index) => {
+      if (seenAids.has(video.aid)) {
+        return [];
+      }
+      seenAids.add(video.aid);
+
+      return [
+        {
+          videoAid: video.aid,
+          recommendedByAid: sourceAid,
+          order: index,
+        },
+      ];
+    });
   }
 }

--- a/src/services/tracker.ts
+++ b/src/services/tracker.ts
@@ -199,32 +199,46 @@ export class DynamicTracker {
   private async processPage(
     dynamics: BiliDynamicCard[],
     depth = 0,
+    seenRelatedCandidates = new Set<string>(),
   ): Promise<VideoData[]> {
     const results: VideoData[] = [];
     const relatedQueue: BiliDynamicCard[] = [];
 
-    const enableRecommendation =
-      config.processing?.features?.enableRecommendation ?? false;
-    const maxDepth = config.processing?.features?.maxRecommendationDepth ?? 1;
+    const features = config.processing?.features;
+    const recordRelatedEdges = features?.enableRelatedQualitySignal ?? true;
+    const enableRelatedExpansion =
+      features?.enableRelatedExpansion ??
+      features?.enableRecommendation ??
+      false;
+    const maxDepth =
+      features?.maxRelatedExpansionDepth ??
+      features?.maxRecommendationDepth ??
+      1;
+    const expandRelated = enableRelatedExpansion && depth < maxDepth;
+
+    for (const dynamic of dynamics) {
+      const key = this.getRelatedCandidateKey(dynamic);
+      if (key) {
+        seenRelatedCandidates.add(key);
+      }
+    }
 
     // Process all dynamics concurrently
     const processResults = await Promise.allSettled(
       dynamics.map(async (dynamic) => {
         try {
           const { video, relatedVideos } =
-            await this.detailsService.processVideo(
-              dynamic,
-              enableRecommendation && depth < maxDepth,
-            );
+            await this.detailsService.processVideo(dynamic, {
+              processRecommendations: recordRelatedEdges,
+              processRelated: expandRelated,
+            });
 
           if (video) {
-            if (
-              enableRecommendation &&
-              depth < maxDepth &&
-              relatedVideos.length > 0
-            ) {
-              return { video, relatedVideos: relatedVideos };
-            }
+            return {
+              video,
+              relatedVideos:
+                expandRelated && relatedVideos.length > 0 ? relatedVideos : [],
+            };
           }
           return null;
         } catch (error) {
@@ -252,13 +266,22 @@ export class DynamicTracker {
 
       if (result.value) {
         results.push(result.value.video);
-        relatedQueue.push(...result.value.relatedVideos);
+        relatedQueue.push(
+          ...this.dedupeRelatedCandidates(
+            result.value.relatedVideos,
+            seenRelatedCandidates,
+          ),
+        );
       }
     }
 
     // Recursive processing for related videos
     if (relatedQueue.length > 0) {
-      const relatedResults = await this.processPage(relatedQueue, depth + 1);
+      const relatedResults = await this.processPage(
+        relatedQueue,
+        depth + 1,
+        seenRelatedCandidates,
+      );
       results.push(...relatedResults);
     }
 
@@ -268,6 +291,39 @@ export class DynamicTracker {
     );
 
     return results;
+  }
+
+  private dedupeRelatedCandidates(
+    candidates: BiliDynamicCard[],
+    seenCandidates: Set<string>,
+  ): BiliDynamicCard[] {
+    const deduped: BiliDynamicCard[] = [];
+
+    for (const candidate of candidates) {
+      const key = this.getRelatedCandidateKey(candidate);
+      if (!key || seenCandidates.has(key)) {
+        continue;
+      }
+
+      seenCandidates.add(key);
+      deduped.push(candidate);
+    }
+
+    return deduped;
+  }
+
+  private getRelatedCandidateKey(candidate: BiliDynamicCard): string | null {
+    const bvid = candidate.desc?.bvid;
+    if (bvid) {
+      return `bvid:${bvid}`;
+    }
+
+    const aid = candidate.desc?.rid;
+    if (aid) {
+      return `aid:${aid.toString()}`;
+    }
+
+    return null;
   }
 
   async runRetrospective() {


### PR DESCRIPTION
## Summary
- splits related video signal handling from expansion behavior
- keeps feature behavior and configuration changes from the implementation track

## Config
- includes the related-videos feature configuration from the completed implementation
- note: `src/scripts/import-csv.ts` still uses legacy recommendation config names

## Checks
- no checks rerun in publish step; relying on completed track verification